### PR TITLE
The admin views look great, but I needed to make a few changes...

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,4 +8,5 @@ recursive-include example_project *.py
 include example_project/requirements.txt
 recursive-include example_project/templates *.html
 recursive-include guardian/fixtures *.json
+recursive-include guardian/templates *.html
 recursive-include docs *


### PR DESCRIPTION
First, the templates weren't included in MANIFEST.in.

Second, I have an app that is not mounted at the root URL, and the URL construction in the admin views didn't work with it. I changed them to use django.core.urlresolvers.reverse, supplying the name of the admin site. I also supplied current_app to the RequestContext built in each, not because its omission broke anything for me, but because that's what the docs say you should do:

http://docs.djangoproject.com/en/1.2/ref/contrib/admin/#adding-views-to-admin-sites

Presumably it will help those who do have multiple admin sites.

Thanks again for the admin integration. It will be very nice for managing permissions that don't need to be exposed through the app.
