### PR TITLE
Minor addition for Django 1.3

### DIFF
--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -7,6 +7,7 @@ from guardian.core import ObjectPermissionChecker
 class ObjectPermissionBackend(object):
     supports_object_permissions = True
     supports_anonymous_user = True
+    supports_inactive_user = True
 
     def authenticate(self, username, password):
         return None


### PR DESCRIPTION
Django 1.3 (dev) has deprecated backends that don't have the 'supports_inactive_user' attribute set. As far as I can tell, there's no reason for it to be set to False for django-guardian.
