### PR TITLE
Make permission_required_or_403 raise PermissionDenied

### DIFF
--- a/guardian/decorators.py
+++ b/guardian/decorators.py
@@ -1,7 +1,8 @@
 
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.http import HttpResponseForbidden, HttpResponseRedirect
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseRedirect
 from django.utils.functional import wraps
 from django.utils.http import urlquote
 from django.db.models import Model, get_model
@@ -25,8 +26,8 @@ def permission_required(perm, lookup_variables=None, **kwargs):
     :param redirect_field_name: name of the parameter passed if redirected.
       Defaults to ``django.contrib.auth.REDIRECT_FIELD_NAME``.
     :param return_403: if set to ``True`` then instead of redirecting to the
-      login page, response with status code 403 is returned (
-      ``django.http.HttpResponseForbidden`` instance). Defaults to ``False``.
+      login page, response with status code 403 is returned by raising the
+      ``PermissionDenied`` exception. Defaults to ``False``.
 
     Examples::
 
@@ -94,7 +95,7 @@ def permission_required(perm, lookup_variables=None, **kwargs):
             # as ``obj`` defaults to None
             if not request.user.has_perm(perm, obj):
                 if return_403:
-                    return HttpResponseForbidden()
+                    raise PermissionDenied()
                 else:
                     path = urlquote(request.get_full_path())
                     tup = login_url, redirect_field_name, path

--- a/guardian/tests/decorators_test.py
+++ b/guardian/tests/decorators_test.py
@@ -1,8 +1,8 @@
 from django.test import TestCase
 from django.contrib.auth.models import User, Group, AnonymousUser
+from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest
 from django.http import HttpResponse
-from django.http import HttpResponseForbidden
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 
@@ -46,7 +46,7 @@ class PermissionRequiredTest(TestCase):
         @permission_required_or_403('not_installed_app.change_user')
         def dummy_view(request):
             return HttpResponse('dummy_view')
-        self.assertTrue(isinstance(dummy_view(request), HttpResponseForbidden))
+        self.assertRaises(PermissionDenied, dummy_view, request)
 
     def test_anonymous_user_wrong_codename(self):
 
@@ -55,7 +55,7 @@ class PermissionRequiredTest(TestCase):
         @permission_required_or_403('auth.wrong_codename')
         def dummy_view(request):
             return HttpResponse('dummy_view')
-        self.assertTrue(isinstance(dummy_view(request), HttpResponseForbidden))
+        self.assertRaises(PermissionDenied, dummy_view, request)
 
     def test_anonymous_user(self):
 
@@ -64,7 +64,7 @@ class PermissionRequiredTest(TestCase):
         @permission_required_or_403('auth.change_user')
         def dummy_view(request):
             return HttpResponse('dummy_view')
-        self.assertTrue(isinstance(dummy_view(request), HttpResponseForbidden))
+        self.assertRaises(PermissionDenied, dummy_view, request)
 
     def test_wrong_lookup_variables_number(self):
 


### PR DESCRIPTION
The `permission_required_or_403` decorator returned a `HttpResponseForbidden` if the user doesn't have permission, but Django provides an exception called `PermissionDenied` that gets converted into an equivalent response (that has `<h1>Permission denied</h1>` as its content), and if you raise the exception it's easy for others to catch it with a middleware and convert it into a nice, themed error page.

This pull request changes `permission_required_or_403` so that it raises `PermissionDenied` and updates the tests accordingly.
