### PR TITLE
Fix 'broken' grappelli tests.

### DIFF
--- a/guardian/tests/admin_test.py
+++ b/guardian/tests/admin_test.py
@@ -353,7 +353,7 @@ class GuardedModelAdminTests(TestCase):
 
 class GrappelliGuardedModelAdminTests(TestCase):
 
-    org_settings = copy.copy(settings)
+    org_installed_apps = copy.copy(settings.INSTALLED_APPS)
 
     def _get_gma(self, attrs=None, name=None, model=None):
         """
@@ -370,7 +370,7 @@ class GrappelliGuardedModelAdminTests(TestCase):
         settings.INSTALLED_APPS = ['grappelli'] + list(settings.INSTALLED_APPS)
 
     def tearDown(self):
-        globals()['settings'] = copy.copy(self.org_settings)
+        settings.INSTALLED_APPS = self.org_installed_apps
 
     def test_get_obj_perms_manage_template(self):
         gma = self._get_gma()


### PR DESCRIPTION
The grappelli tests were not restoring the settings.INSTALLED_APPS list
correctly. When the three grappelli tests were done running there would
be three copies of that app in the INSTALLED_APPS lists.
