### PR TITLE
Unit tests - test fixture - object order correction

### DIFF
--- a/guardian/fixtures/tests.json
+++ b/guardian/fixtures/tests.json
@@ -1,5 +1,21 @@
 [
     {
+        "pk": 1, 
+        "model": "auth.group", 
+        "fields": {
+            "name": "admins", 
+            "permissions": []
+        }
+    },
+    {
+        "pk": 2,
+        "model": "auth.group", 
+        "fields": {
+            "name": "jackGroup", 
+            "permissions": []
+        }
+    },
+    {
         "pk": -1, 
         "model": "auth.user", 
         "fields": {
@@ -33,22 +49,6 @@
             "password": "", 
             "email": "", 
             "date_joined": "2010-05-28 04:02:34"
-        }
-    }, 
-    {
-        "pk": 1, 
-        "model": "auth.group", 
-        "fields": {
-            "name": "admins", 
-            "permissions": []
-        }
-    },
-    {
-        "pk": 2,
-        "model": "auth.group", 
-        "fields": {
-            "name": "jackGroup", 
-            "permissions": []
         }
     }
 ]


### PR DESCRIPTION
tests.json defines users which reference group IDs before defining those group IDs.  

On databases with referential integrity constraints, this causes an exception to be raised when the test runner attempts to install the fixture, and causes associated tests to fail since the fixture does not get installed.

The fix is simply to define the groups first, THEN define the users which reference those groups. 

The attached commit makes that change.
