### PR TITLE
Added tests/templates to settings before try render dummy403.html

### DIFF
--- a/guardian/tests/decorators_test.py
+++ b/guardian/tests/decorators_test.py
@@ -62,7 +62,7 @@ class PermissionRequiredTest(TestCase):
         def dummy_view(request):
             return HttpResponse('dummy_view')
         
-        settings.TEMPLATE_DIRS += os.path.join(os.path.dirname(__file__), 'tests/templates/')
+        settings.TEMPLATE_DIRS += os.path.join(os.path.dirname(__file__), 'templates/')
         with mock.patch('guardian.conf.settings.TEMPLATE_403', 'dummy403.html'):
             response = dummy_view(request)
             self.assertEqual(response.content, 'foobar403\n')


### PR DESCRIPTION
The test_TEMPLATE_403_setting  fails because render(dummy403).html doesn't exists.. it happens because by default templates folder is only point to my_app/templates/ not to tests/templates/ 
