### PR TITLE
Fix for long int values in templates

### DIFF
--- a/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage.html
+++ b/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage.html
@@ -63,7 +63,7 @@
                         </td>
                         {% endfor %}
                         <td>
-                            <a href="user-manage/{{ user.id }}/">{% trans "Edit" %}</a>
+                            <a href="user-manage/{{ user.id|safe }}/">{% trans "Edit" %}</a>
                         </td>
                     </tr>
                     {% endfor %}
@@ -123,7 +123,7 @@
                         </td>
                         {% endfor %}
                         <td>
-                            <a href="group-manage/{{ group.id }}/">{% trans "Edit" %}</a>
+                            <a href="group-manage/{{ group.id|safe }}/">{% trans "Edit" %}</a>
                         </td>
                     </tr>
                     {% endfor %}

--- a/guardian/templates/admin/guardian/model/obj_perms_manage.html
+++ b/guardian/templates/admin/guardian/model/obj_perms_manage.html
@@ -58,7 +58,7 @@
                         </td>
                         {% endfor %}
                         <td>
-                            <a href="user-manage/{{ user.id }}/">{% trans "Edit" %}</a>
+                            <a href="user-manage/{{ user.id|safe }}/">{% trans "Edit" %}</a>
                         </td>
                     </tr>
                     {% endfor %}
@@ -112,7 +112,7 @@
                         </td>
                         {% endfor %}
                         <td>
-                            <a href="group-manage/{{ group.id }}/">{% trans "Edit" %}</a>
+                            <a href="group-manage/{{ group.id|safe }}/">{% trans "Edit" %}</a>
                         </td>            
                     </tr>
                     {% endfor %}


### PR DESCRIPTION
Example:

id = 1234567

In template «{{ id }}» for my local output «123 456 7»
