### PR TITLE
Removed {% load adminmedia %} from templates

### DIFF
--- a/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage.html
+++ b/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage.html
@@ -1,6 +1,5 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
-{% load adminmedia %}
 
 {% block extrahead %}{{ block.super }}
 <style type="text/css">

--- a/guardian/templates/admin/guardian/model/obj_perms_manage.html
+++ b/guardian/templates/admin/guardian/model/obj_perms_manage.html
@@ -1,6 +1,5 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
-{% load adminmedia %}
 
 {% block extrahead %}{{ block.super }}
 <style type="text/css">

--- a/guardian/templates/admin/guardian/model/obj_perms_no.html
+++ b/guardian/templates/admin/guardian/model/obj_perms_no.html
@@ -1,2 +1,1 @@
-{% load adminmedia %}
 <img src="{{ STATIC_URL }}admin/img/icon-no.gif"/>

--- a/guardian/templates/admin/guardian/model/obj_perms_yes.html
+++ b/guardian/templates/admin/guardian/model/obj_perms_yes.html
@@ -1,2 +1,1 @@
-{% load adminmedia %}
 <img src="{{ STATIC_URL }}admin/img/icon-yes.gif"/>


### PR DESCRIPTION
Deprecated in [Django1.5](https://docs.djangoproject.com/en/1.5/releases/1.5/#miscellaneous)
