### PR TITLE
Do not use defaults module from django.conf.urls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Authors ordered by first contribution
 - Ali Lozano <alilozanoc@gmail.com>
 - BJ Dierkes <derks@bjdierkes.com>
 - Rach Belaid <rachid.belaid@gmail.com>
+- Michael Crosby <crosby.michael@gmail.com>

--- a/example_project/posts/urls.py
+++ b/example_project/posts/urls.py
@@ -1,7 +1,4 @@
-try:
-    from django.conf.urls import patterns, url
-except ImportError:
-    from django.conf.urls.defaults import patterns, url
+from guardian.compat import url, include, patterns, handler404, handler500
 
 
 urlpatterns = patterns('posts.views',

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -1,7 +1,4 @@
-try:
-    from django.conf.urls import patterns, url, include
-except ImportError:
-    from django.conf.urls.defaults import patterns, url, include
+from guardian.compat import url, include, patterns, handler404, handler500
 from django.conf import settings
 from django.contrib import admin
 

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -1,9 +1,6 @@
 from django import forms
 from django.conf import settings
-try:
-    from django.conf.urls import patterns, url
-except ImportError:
-    from django.conf.urls.defaults import patterns, url
+from guardian.compat import url, patterns
 from django.contrib import admin
 from django.contrib import messages
 from django.contrib.admin.widgets import FilteredSelectMultiple

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -3,8 +3,22 @@ from django.contrib.auth.models import Group
 from django.contrib.auth.models import Permission
 from django.contrib.auth.models import AnonymousUser
 
+try:
+    from django.conf.urls import url, patterns, include, handler404, handler500
+except ImportError:
+    from django.conf.urls.defaults import url, patterns, include, handler404, handler500
 
-__all__ = ['User', 'Group', 'Permission', 'AnonymousUser']
+__all__ = [
+    'User',
+    'Group',
+    'Permission',
+    'AnonymousUser',
+    'url',
+    'patterns',
+    'include',
+    'handler404',
+    'handler500'
+]
 
 # Django 1.5+ compatibility
 if django.VERSION >= (1, 5):

--- a/guardian/tests/urls.py
+++ b/guardian/tests/urls.py
@@ -1,7 +1,4 @@
-try:
-    from django.conf.urls import patterns, include
-except ImportError:
-    from django.conf.urls.defaults import *
+from guardian.compat import url, include, patterns, handler404, handler500
 from django.contrib import admin
 
 admin.autodiscover()


### PR DESCRIPTION
django.conf.urls.defaults is deprecated.

patterns, url, and include should be imported via django.conf.urls

django.conf.urls.defaults will still be used if the installed django version is less than 1.4
