### PR TITLE
Defined view mixin properties required for "get_object()"

### DIFF
--- a/guardian/mixins.py
+++ b/guardian/mixins.py
@@ -166,6 +166,9 @@ class PermissionRequiredMixin(object):
         """
 
     def dispatch(self, request, *args, **kwargs):
+        self.request = request
+        self.args = args
+        self.kwargs = kwargs
         response = self.check_permissions(request)
         if response:
             return response


### PR DESCRIPTION
Calling get_object() when checking view permissions via the PermissionRequiredMixin was missing a few properties that getting the object requires, which are normally set in the base View dispatch method. As that method doesn't get called unless the permission check passes, we need to set them ourselves first
