### PR TITLE
Globally renamed 'assign' method/function to 'assign_perm'. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ dist
 example_project/media
 example_project/conf/*.py
 .idea/
+
+# WebDAV remote filesystem
+.DAV

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Lets start really quickly::
     >>> admins = Group.objects.create(name='admins')
     >>> jack.has_perm('change_group', admins)
     False
-    >>> UserObjectPermission.objects.assign('change_group', user=jack, obj=admins)
+    >>> UserObjectPermission.objects.assign_perm('change_group', user=jack, obj=admins)
     <UserObjectPermission: admins | jack | change_group>
     >>> jack.has_perm('change_group', admins)
     True

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -20,7 +20,7 @@ sys.path.insert(0, ROOT_DIR)
 
 os.environ["DJANGO_SETTINGS_MODULE"] = 'benchmarks.settings'
 from benchmarks import settings
-from guardian.shortcuts import assign
+from guardian.shortcuts import assign_perm
 
 settings.DJALOG_LEVEL = 40
 settings.INSTALLED_APPS = (
@@ -126,7 +126,7 @@ class Benchmark(object):
                 self.grant_perm(user, obj, self.perm)
 
     def grant_perm(self, user, obj, perm):
-        assign(perm, user, obj)
+        assign_perm(perm, user, obj)
 
     @Timed("Check permissions")
     def check_perms(self):

--- a/docs/userguide/assign.rst
+++ b/docs/userguide/assign.rst
@@ -60,7 +60,7 @@ Assign object permissions
 -------------------------
 
 We can assign permissions for any user/group and object pairs using same,
-convenient function: :func:`guardian.shortcuts.assign`.
+convenient function: :func:`guardian.shortcuts.assign_perm`.
 
 For user
 ~~~~~~~~
@@ -79,8 +79,8 @@ Well, not so fast Joe, let us create an object permission finally:
 
 .. code-block:: python
 
-    >>> from guardian.shortcuts import assign
-    >>> assign('view_task', joe, task)
+    >>> from guardian.shortcuts import assign_perm
+    >>> assign_perm('view_task', joe, task)
     >>> joe.has_perm('view_task', task)
     True
 
@@ -94,7 +94,7 @@ difference is we have to pass ``Group`` instance rather than ``User``.
 .. code-block:: python
 
     >>> group = Group.objects.create(name='employees')
-    >>> assign('change_task', group, task)
+    >>> assign_perm('change_task', group, task)
     >>> joe.has_perm('change_task', task)
     False
     >>> # Well, joe is not yet within an *employees* group

--- a/docs/userguide/check.rst
+++ b/docs/userguide/check.rst
@@ -24,8 +24,8 @@ additional argument::
 
 Lets assign permission and check again::
 
-    >>> from guardian.shortcuts import assign
-    >>> assign('sites.change_site', joe, site)
+    >>> from guardian.shortcuts import assign_perm
+    >>> assign_perm('sites.change_site', joe, site)
     <UserObjectPermission: example.com | joe | change_site>
     >>> joe = User.objects.get(username='joe')
     >>> joe.has_perm('sites.change_site', site)
@@ -147,8 +147,8 @@ decorator::
     >>> edit_group(request, group_name='foobars')
     <django.http.HttpResponseForbidden object at 0x102b43e50>
     >>>
-    >>> from guardian.shortcuts import assign
-    >>> assign('auth.change_group', joe, foobars)
+    >>> from guardian.shortcuts import assign_perm
+    >>> assign_perm('auth.change_group', joe, foobars)
     <UserObjectPermission: foobars | joe | change_group>
     >>>
     >>> edit_group(request, group_name='foobars')

--- a/docs/userguide/performance.rst
+++ b/docs/userguide/performance.rst
@@ -42,10 +42,10 @@ In order to add a *change_project* permission for *joe* user we would use
 
 .. code-block:: python
 
-    >>> from guardian.shortcuts import assign
+    >>> from guardian.shortcuts import assign_perm
     >>> project = Project.objects.get(name='Foobar')
     >>> joe = User.objects.get(username='joe')
-    >>> assign('change_project', joe, project)
+    >>> assign_perm('change_project', joe, project)
 
 What it really does is: create an instance of :model:`UserObjectPermission`.
 Something similar to:

--- a/guardian/forms.py
+++ b/guardian/forms.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django import forms
 from django.utils.translation import ugettext as _
 
-from guardian.shortcuts import assign
+from guardian.shortcuts import assign_perm
 from guardian.shortcuts import remove_perm
 from guardian.shortcuts import get_perms
 from guardian.shortcuts import get_perms_for_model
@@ -143,7 +143,7 @@ class UserObjectPermissionsForm(BaseObjectPermissionsForm):
             remove_perm(perm, self.user, self.obj)
 
         for perm in perms:
-            assign(perm, self.user, self.obj)
+            assign_perm(perm, self.user, self.obj)
 
 
 class GroupObjectPermissionsForm(BaseObjectPermissionsForm):
@@ -190,5 +190,5 @@ class GroupObjectPermissionsForm(BaseObjectPermissionsForm):
             remove_perm(perm, self.group, self.obj)
 
         for perm in perms:
-            assign(perm, self.group, self.obj)
+            assign_perm(perm, self.group, self.obj)
 

--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 
 from guardian.exceptions import ObjectNotPersisted
 from guardian.models import Permission
+import warnings
 
 # TODO: consolidate UserObjectPermissionManager and GroupObjectPermissionManager
 
@@ -20,7 +21,7 @@ class BaseObjectPermissionManager(models.Manager):
 
 class UserObjectPermissionManager(BaseObjectPermissionManager):
 
-    def assign(self, perm, user, obj):
+    def assign_perm(self, perm, user, obj):
         """
         Assigns permission with given ``perm`` for an instance ``obj`` and
         ``user``.
@@ -39,6 +40,11 @@ class UserObjectPermissionManager(BaseObjectPermissionManager):
             kwargs['content_object'] = obj
         obj_perm, created = self.get_or_create(**kwargs)
         return obj_perm
+
+    def assign(self, perm, user, obj):
+        """ Depreciated function name left in for compatibility"""
+        warnings.warn("UserObjectPermissionManager method 'assign' is being renamed to 'assign_perm'. Update your code accordingly as old name will be depreciated in 1.0.5 version.", DeprecationWarning)
+        return self.assign_perm(perm, user, obj)
 
     def remove_perm(self, perm, user, obj):
         """
@@ -72,7 +78,7 @@ class UserObjectPermissionManager(BaseObjectPermissionManager):
 
 class GroupObjectPermissionManager(BaseObjectPermissionManager):
 
-    def assign(self, perm, group, obj):
+    def assign_perm(self, perm, group, obj):
         """
         Assigns permission with given ``perm`` for an instance ``obj`` and
         ``group``.
@@ -91,6 +97,11 @@ class GroupObjectPermissionManager(BaseObjectPermissionManager):
             kwargs['content_object'] = obj
         obj_perm, created = self.get_or_create(**kwargs)
         return obj_perm
+
+    def assign(self, perm, user, obj):
+        """ Depreciated function name left in for compatibility"""
+        warnings.warn("UserObjectPermissionManager method 'assign' is being renamed to 'assign_perm'. Update your code accordingly as old name will be depreciated in 1.0.5 version.", DeprecationWarning)
+        return self.assign_perm(perm, user, obj)
 
     def remove_perm(self, perm, group, obj):
         """

--- a/guardian/models.py
+++ b/guardian/models.py
@@ -90,12 +90,12 @@ User = get_user_model()
 # Prototype User and Group methods
 setattr(User, 'get_anonymous', staticmethod(lambda: get_anonymous_user()))
 setattr(User, 'add_obj_perm',
-    lambda self, perm, obj: UserObjectPermission.objects.assign(perm, self, obj))
+    lambda self, perm, obj: UserObjectPermission.objects.assign_perm(perm, self, obj))
 setattr(User, 'del_obj_perm',
     lambda self, perm, obj: UserObjectPermission.objects.remove_perm(perm, self, obj))
 
 setattr(Group, 'add_obj_perm',
-    lambda self, perm, obj: GroupObjectPermission.objects.assign(perm, self, obj))
+    lambda self, perm, obj: GroupObjectPermission.objects.assign_perm(perm, self, obj))
 setattr(Group, 'del_obj_perm',
     lambda self, perm, obj: GroupObjectPermission.objects.remove_perm(perm, self, obj))
 

--- a/guardian/tests/core_test.py
+++ b/guardian/tests/core_test.py
@@ -12,7 +12,7 @@ from guardian.core import ObjectPermissionChecker
 from guardian.compat import get_user_model
 from guardian.exceptions import NotUserNorGroup
 from guardian.models import UserObjectPermission, GroupObjectPermission
-from guardian.shortcuts import assign
+from guardian.shortcuts import assign_perm
 
 User = get_user_model()
 
@@ -115,7 +115,7 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
 
     def test_not_active_user(self):
         user = User.objects.create(username='notactive')
-        assign("change_contenttype", user, self.ctype)
+        assign_perm("change_contenttype", user, self.ctype)
 
         # new ObjectPermissionChecker is created for each User.has_perm call
         self.assertTrue(user.has_perm("change_contenttype", self.ctype))
@@ -125,7 +125,7 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
         # use on one checker only (as user's is_active attr should be checked
         # before try to use cache
         user = User.objects.create(username='notactive-cache')
-        assign("change_contenttype", user, self.ctype)
+        assign_perm("change_contenttype", user, self.ctype)
 
         check = ObjectPermissionChecker(user)
         self.assertTrue(check.has_perm("change_contenttype", self.ctype))
@@ -149,13 +149,13 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
 
         for obj, perms in assign_perms.items():
             for perm in perms:
-                UserObjectPermission.objects.assign(perm, self.user, obj)
+                UserObjectPermission.objects.assign_perm(perm, self.user, obj)
             self.assertEqual(sorted(perms), sorted(check.get_perms(obj)))
 
         check = ObjectPermissionChecker(self.group)
 
         for obj, perms in assign_perms.items():
             for perm in perms:
-                GroupObjectPermission.objects.assign(perm, self.group, obj)
+                GroupObjectPermission.objects.assign_perm(perm, self.group, obj)
             self.assertEqual(sorted(perms), sorted(check.get_perms(obj)))
 

--- a/guardian/tests/custompkmodel_test.py
+++ b/guardian/tests/custompkmodel_test.py
@@ -3,7 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from guardian.compat import get_user_model
-from guardian.shortcuts import assign, remove_perm
+from guardian.shortcuts import assign_perm, remove_perm
 
 
 class CustomPKModelTest(TestCase):
@@ -17,13 +17,13 @@ class CustomPKModelTest(TestCase):
         self.ctype = ContentType.objects.create(name='foo', model='bar',
             app_label='fake-for-guardian-tests')
 
-    def test_assign(self):
-        assign('contenttypes.change_contenttype', self.user, self.ctype)
+    def test_assign_perm(self):
+        assign_perm('contenttypes.change_contenttype', self.user, self.ctype)
         self.assertTrue(self.user.has_perm('contenttypes.change_contenttype',
             self.ctype))
 
     def test_remove_perm(self):
-        assign('contenttypes.change_contenttype', self.user, self.ctype)
+        assign_perm('contenttypes.change_contenttype', self.user, self.ctype)
         self.assertTrue(self.user.has_perm('contenttypes.change_contenttype',
             self.ctype))
         remove_perm('contenttypes.change_contenttype', self.user, self.ctype)

--- a/guardian/tests/decorators_test.py
+++ b/guardian/tests/decorators_test.py
@@ -18,7 +18,7 @@ from guardian.compat import get_user_permission_full_codename
 from guardian.decorators import permission_required, permission_required_or_403
 from guardian.exceptions import GuardianError
 from guardian.exceptions import WrongAppError
-from guardian.shortcuts import assign
+from guardian.shortcuts import assign_perm
 from guardian.tests.conf import TEST_SETTINGS
 from guardian.tests.conf import TestDataMixin
 from guardian.tests.conf import override_settings
@@ -195,7 +195,7 @@ class PermissionRequiredTest(TestDataMixin, TestCase):
 
         perm = get_user_permission_full_codename('change')
         joe, created = User.objects.get_or_create(username='joe')
-        assign(perm, self.user, obj=joe)
+        assign_perm(perm, self.user, obj=joe)
 
         request = self._get_request(self.user)
 
@@ -226,7 +226,7 @@ class PermissionRequiredTest(TestDataMixin, TestCase):
             __metaclass__ = TestMeta
 
         joe, created = ProxyUser.objects.get_or_create(username='joe')
-        assign(perm, self.user, obj=joe)
+        assign_perm(perm, self.user, obj=joe)
 
         request = self._get_request(self.user)
 
@@ -242,7 +242,7 @@ class PermissionRequiredTest(TestDataMixin, TestCase):
 
         perm = get_user_permission_full_codename('change')
         joe, created = User.objects.get_or_create(username='joe')
-        assign(perm, self.user, obj=joe)
+        assign_perm(perm, self.user, obj=joe)
 
         request = self._get_request(self.user)
 
@@ -272,7 +272,7 @@ class PermissionRequiredTest(TestDataMixin, TestCase):
 
         perm = get_user_permission_full_codename('change')
         joe, created = User.objects.get_or_create(username='joe')
-        assign(perm, self.user)
+        assign_perm(perm, self.user)
 
         request = self._get_request(self.user)
 
@@ -287,7 +287,7 @@ class PermissionRequiredTest(TestDataMixin, TestCase):
 
         perm = get_user_permission_full_codename('change')
         joe, created = User.objects.get_or_create(username='joe')
-        assign(perm, self.user)
+        assign_perm(perm, self.user)
 
         request = self._get_request(self.user)
 
@@ -305,7 +305,7 @@ class PermissionRequiredTest(TestDataMixin, TestCase):
 
         perm = get_user_permission_full_codename('change')
         joe, created = User.objects.get_or_create(username='joe')
-        assign(perm, self.user, obj=joe)
+        assign_perm(perm, self.user, obj=joe)
 
         models = (
             user_model_path,

--- a/guardian/tests/direct_rel_test.py
+++ b/guardian/tests/direct_rel_test.py
@@ -6,7 +6,7 @@ from .testapp.models import ProjectUserObjectPermission
 from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
 from guardian.compat import get_user_model
-from guardian.shortcuts import assign
+from guardian.shortcuts import assign_perm
 from guardian.shortcuts import get_groups_with_perms
 from guardian.shortcuts import get_objects_for_group
 from guardian.shortcuts import get_objects_for_user
@@ -39,8 +39,8 @@ class TestDirectUserPermissions(TestCase):
         )
         self.assertTrue(self.joe.has_perm('add_project', self.project))
 
-    def test_assign(self):
-        assign('add_project', self.joe, self.project)
+    def test_assign_perm(self):
+        assign_perm('add_project', self.joe, self.project)
         filters = {
             'content_object': self.project,
             'permission__codename': 'add_project',
@@ -50,7 +50,7 @@ class TestDirectUserPermissions(TestCase):
         self.assertEqual(result, 1)
 
     def test_remove_perm(self):
-        assign('add_project', self.joe, self.project)
+        assign_perm('add_project', self.joe, self.project)
         filters = {
             'content_object': self.project,
             'permission__codename': 'add_project',
@@ -66,9 +66,9 @@ class TestDirectUserPermissions(TestCase):
     def test_get_users_with_perms(self):
         User.objects.create_user('john', 'john@foobar.com', 'john')
         jane = User.objects.create_user('jane', 'jane@foobar.com', 'jane')
-        assign('add_project', self.joe, self.project)
-        assign('change_project', self.joe, self.project)
-        assign('change_project', jane, self.project)
+        assign_perm('add_project', self.joe, self.project)
+        assign_perm('change_project', self.joe, self.project)
+        assign_perm('change_project', jane, self.project)
         self.assertEqual(get_users_with_perms(self.project, attach_perms=True),
             {
                 self.joe: ['add_project', 'change_project'],
@@ -80,9 +80,9 @@ class TestDirectUserPermissions(TestCase):
         jane = User.objects.create_user('jane', 'jane@foobar.com', 'jane')
         group = Group.objects.create(name='devs')
         self.joe.groups.add(group)
-        assign('add_project', self.joe, self.project)
-        assign('change_project', group, self.project)
-        assign('change_project', jane, self.project)
+        assign_perm('add_project', self.joe, self.project)
+        assign_perm('change_project', group, self.project)
+        assign_perm('change_project', jane, self.project)
         self.assertEqual(get_users_with_perms(self.project, attach_perms=True),
             {
                 self.joe: ['add_project', 'change_project'],
@@ -92,9 +92,9 @@ class TestDirectUserPermissions(TestCase):
     def test_get_objects_for_user(self):
         foo = Project.objects.create(name='foo')
         bar = Project.objects.create(name='bar')
-        assign('add_project', self.joe, foo)
-        assign('add_project', self.joe, bar)
-        assign('change_project', self.joe, bar)
+        assign_perm('add_project', self.joe, foo)
+        assign_perm('add_project', self.joe, bar)
+        assign_perm('change_project', self.joe, bar)
 
         result = get_objects_for_user(self.joe, 'testapp.add_project')
         self.assertEqual(sorted(p.pk for p in result), sorted([foo.pk, bar.pk]))
@@ -124,8 +124,8 @@ class TestDirectGroupPermissions(TestCase):
         )
         self.assertTrue(self.joe.has_perm('add_project', self.project))
 
-    def test_assign(self):
-        assign('add_project', self.group, self.project)
+    def test_assign_perm(self):
+        assign_perm('add_project', self.group, self.project)
         filters = {
             'content_object': self.project,
             'permission__codename': 'add_project',
@@ -135,7 +135,7 @@ class TestDirectGroupPermissions(TestCase):
         self.assertEqual(result, 1)
 
     def test_remove_perm(self):
-        assign('add_project', self.group, self.project)
+        assign_perm('add_project', self.group, self.project)
         filters = {
             'content_object': self.project,
             'permission__codename': 'add_project',
@@ -151,9 +151,9 @@ class TestDirectGroupPermissions(TestCase):
     def test_get_groups_with_perms(self):
         Group.objects.create(name='managers')
         devs = Group.objects.create(name='devs')
-        assign('add_project', self.group, self.project)
-        assign('change_project', self.group, self.project)
-        assign('change_project', devs, self.project)
+        assign_perm('add_project', self.group, self.project)
+        assign_perm('change_project', self.group, self.project)
+        assign_perm('change_project', devs, self.project)
         self.assertEqual(get_groups_with_perms(self.project, attach_perms=True),
             {
                 self.group: ['add_project', 'change_project'],
@@ -163,9 +163,9 @@ class TestDirectGroupPermissions(TestCase):
     def test_get_objects_for_group(self):
         foo = Project.objects.create(name='foo')
         bar = Project.objects.create(name='bar')
-        assign('add_project', self.group, foo)
-        assign('add_project', self.group, bar)
-        assign('change_project', self.group, bar)
+        assign_perm('add_project', self.group, foo)
+        assign_perm('add_project', self.group, bar)
+        assign_perm('change_project', self.group, bar)
 
         result = get_objects_for_group(self.group, 'testapp.add_project')
         self.assertEqual(sorted(p.pk for p in result), sorted([foo.pk, bar.pk]))
@@ -184,9 +184,9 @@ class TestMixedDirectAndGenericObjectPermission(TestCase):
         jane = User.objects.create_user('jane', 'jane@foobar.com', 'jane')
         group = Group.objects.create(name='devs')
         self.joe.groups.add(group)
-        assign('add_mixed', self.joe, self.mixed)
-        assign('change_mixed', group, self.mixed)
-        assign('change_mixed', jane, self.mixed)
+        assign_perm('add_mixed', self.joe, self.mixed)
+        assign_perm('change_mixed', group, self.mixed)
+        assign_perm('change_mixed', jane, self.mixed)
         self.assertEqual(get_users_with_perms(self.mixed, attach_perms=True),
             {
                 self.joe: ['add_mixed', 'change_mixed'],

--- a/guardian/tests/orphans_test.py
+++ b/guardian/tests/orphans_test.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 
 from guardian.compat import get_user_model
 from guardian.utils import clean_orphan_obj_perms
-from guardian.shortcuts import assign
+from guardian.shortcuts import assign_perm
 from guardian.models import Group
 
 
@@ -45,7 +45,7 @@ class OrphanedObjectPermissionsTest(TestCase):
         for target, perms in target_perms.items():
             target.__old_pk = target.pk # Store pkeys
             for perm in perms:
-                assign(perm, self.user, target)
+                assign_perm(perm, self.user, target)
 
         # Remove targets
         for target, perms in target_perms.items():
@@ -78,7 +78,7 @@ class OrphanedObjectPermissionsTest(TestCase):
         for target, perms in target_perms.items():
             target.__old_pk = target.pk # Store pkeys
             for perm in perms:
-                assign(perm, self.user, target)
+                assign_perm(perm, self.user, target)
 
         # Remove targets
         for target, perms in target_perms.items():

--- a/guardian/tests/other_test.py
+++ b/guardian/tests/other_test.py
@@ -42,14 +42,14 @@ class UserPermissionTests(TestDataMixin, TestCase):
     def test_assignement(self):
         self.assertFalse(self.user.has_perm('change_contenttype', self.ctype))
 
-        UserObjectPermission.objects.assign('change_contenttype', self.user,
+        UserObjectPermission.objects.assign_perm('change_contenttype', self.user,
             self.ctype)
         self.assertTrue(self.user.has_perm('change_contenttype', self.ctype))
         self.assertTrue(self.user.has_perm('contenttypes.change_contenttype',
             self.ctype))
 
     def test_assignement_and_remove(self):
-        UserObjectPermission.objects.assign('change_contenttype', self.user,
+        UserObjectPermission.objects.assign_perm('change_contenttype', self.user,
             self.ctype)
         self.assertTrue(self.user.has_perm('change_contenttype', self.ctype))
 
@@ -58,17 +58,17 @@ class UserPermissionTests(TestDataMixin, TestCase):
         self.assertFalse(self.user.has_perm('change_contenttype', self.ctype))
 
     def test_ctypes(self):
-        UserObjectPermission.objects.assign('change_contenttype', self.user, self.obj1)
+        UserObjectPermission.objects.assign_perm('change_contenttype', self.user, self.obj1)
         self.assertTrue(self.user.has_perm('change_contenttype', self.obj1))
         self.assertFalse(self.user.has_perm('change_contenttype', self.obj2))
 
         UserObjectPermission.objects.remove_perm('change_contenttype', self.user, self.obj1)
-        UserObjectPermission.objects.assign('change_contenttype', self.user, self.obj2)
+        UserObjectPermission.objects.assign_perm('change_contenttype', self.user, self.obj2)
         self.assertTrue(self.user.has_perm('change_contenttype', self.obj2))
         self.assertFalse(self.user.has_perm('change_contenttype', self.obj1))
 
-        UserObjectPermission.objects.assign('change_contenttype', self.user, self.obj1)
-        UserObjectPermission.objects.assign('change_contenttype', self.user, self.obj2)
+        UserObjectPermission.objects.assign_perm('change_contenttype', self.user, self.obj1)
+        UserObjectPermission.objects.assign_perm('change_contenttype', self.user, self.obj2)
         self.assertTrue(self.user.has_perm('change_contenttype', self.obj2))
         self.assertTrue(self.user.has_perm('change_contenttype', self.obj1))
 
@@ -87,19 +87,19 @@ class UserPermissionTests(TestDataMixin, TestCase):
         ])
 
         for perm in to_assign:
-            UserObjectPermission.objects.assign(perm, self.user, self.ctype)
+            UserObjectPermission.objects.assign_perm(perm, self.user, self.ctype)
 
         perms = UserObjectPermission.objects.get_for_object(self.user, self.ctype)
         codenames = sorted(chain(*perms.values_list('permission__codename')))
 
         self.assertEqual(to_assign, codenames)
 
-    def test_assign_validation(self):
+    def test_assign_perm_validation(self):
         self.assertRaises(Permission.DoesNotExist,
-            UserObjectPermission.objects.assign, 'change_group', self.user,
+            UserObjectPermission.objects.assign_perm, 'change_group', self.user,
             self.user)
 
-        group = Group.objects.create(name='test_group_assign_validation')
+        group = Group.objects.create(name='test_group_assign_perm_validation')
         ctype = ContentType.objects.get_for_model(group)
         codename = codename=get_user_permission_codename('change')
         perm = Permission.objects.get(codename=codename)
@@ -115,7 +115,7 @@ class UserPermissionTests(TestDataMixin, TestCase):
 
     def test_unicode(self):
         codename = get_user_permission_codename('change')
-        obj_perm = UserObjectPermission.objects.assign(codename,
+        obj_perm = UserObjectPermission.objects.assign_perm(codename,
             self.user, self.user)
         self.assertTrue(isinstance(obj_perm.__unicode__(), unicode))
 
@@ -123,7 +123,7 @@ class UserPermissionTests(TestDataMixin, TestCase):
         not_saved_user = User(username='not_saved_user')
         codename = get_user_permission_codename('change')
         self.assertRaises(ObjectNotPersisted,
-            UserObjectPermission.objects.assign,
+            UserObjectPermission.objects.assign_perm,
             codename, self.user, not_saved_user)
         self.assertRaises(ObjectNotPersisted,
             UserObjectPermission.objects.remove_perm,
@@ -151,14 +151,14 @@ class GroupPermissionTests(TestDataMixin, TestCase):
         self.assertFalse(self.user.has_perm('contenttypes.change_contenttype',
             self.ctype))
 
-        GroupObjectPermission.objects.assign('change_contenttype', self.group,
+        GroupObjectPermission.objects.assign_perm('change_contenttype', self.group,
             self.ctype)
         self.assertTrue(self.user.has_perm('change_contenttype', self.ctype))
         self.assertTrue(self.user.has_perm('contenttypes.change_contenttype',
             self.ctype))
 
     def test_assignement_and_remove(self):
-        GroupObjectPermission.objects.assign('change_contenttype', self.group,
+        GroupObjectPermission.objects.assign_perm('change_contenttype', self.group,
             self.ctype)
         self.assertTrue(self.user.has_perm('change_contenttype', self.ctype))
 
@@ -167,21 +167,21 @@ class GroupPermissionTests(TestDataMixin, TestCase):
         self.assertFalse(self.user.has_perm('change_contenttype', self.ctype))
 
     def test_ctypes(self):
-        GroupObjectPermission.objects.assign('change_contenttype', self.group,
+        GroupObjectPermission.objects.assign_perm('change_contenttype', self.group,
             self.obj1)
         self.assertTrue(self.user.has_perm('change_contenttype', self.obj1))
         self.assertFalse(self.user.has_perm('change_contenttype', self.obj2))
 
         GroupObjectPermission.objects.remove_perm('change_contenttype',
             self.group, self.obj1)
-        GroupObjectPermission.objects.assign('change_contenttype', self.group,
+        GroupObjectPermission.objects.assign_perm('change_contenttype', self.group,
             self.obj2)
         self.assertTrue(self.user.has_perm('change_contenttype', self.obj2))
         self.assertFalse(self.user.has_perm('change_contenttype', self.obj1))
 
-        GroupObjectPermission.objects.assign('change_contenttype', self.group,
+        GroupObjectPermission.objects.assign_perm('change_contenttype', self.group,
             self.obj1)
-        GroupObjectPermission.objects.assign('change_contenttype', self.group,
+        GroupObjectPermission.objects.assign_perm('change_contenttype', self.group,
             self.obj2)
         self.assertTrue(self.user.has_perm('change_contenttype', self.obj2))
         self.assertTrue(self.user.has_perm('change_contenttype', self.obj1))
@@ -206,19 +206,19 @@ class GroupPermissionTests(TestDataMixin, TestCase):
         ])
 
         for perm in to_assign:
-            GroupObjectPermission.objects.assign(perm, group, self.ctype)
+            GroupObjectPermission.objects.assign_perm(perm, group, self.ctype)
 
         perms = GroupObjectPermission.objects.get_for_object(group, self.ctype)
         codenames = sorted(chain(*perms.values_list('permission__codename')))
 
         self.assertEqual(to_assign, codenames)
 
-    def test_assign_validation(self):
+    def test_assign_perm_validation(self):
         self.assertRaises(Permission.DoesNotExist,
-            GroupObjectPermission.objects.assign, 'change_user', self.group,
+            GroupObjectPermission.objects.assign_perm, 'change_user', self.group,
             self.group)
 
-        user = User.objects.create(username='test_user_assign_validation')
+        user = User.objects.create(username='test_user_assign_perm_validation')
         ctype = ContentType.objects.get_for_model(user)
         perm = Permission.objects.get(codename='change_group')
 
@@ -232,14 +232,14 @@ class GroupPermissionTests(TestDataMixin, TestCase):
             **create_info)
 
     def test_unicode(self):
-        obj_perm = GroupObjectPermission.objects.assign("change_group",
+        obj_perm = GroupObjectPermission.objects.assign_perm("change_group",
             self.group, self.group)
         self.assertTrue(isinstance(obj_perm.__unicode__(), unicode))
 
     def test_errors(self):
         not_saved_group = Group(name='not_saved_group')
         self.assertRaises(ObjectNotPersisted,
-            GroupObjectPermission.objects.assign,
+            GroupObjectPermission.objects.assign_perm,
             "change_group", self.group, not_saved_group)
         self.assertRaises(ObjectNotPersisted,
             GroupObjectPermission.objects.remove_perm,
@@ -285,7 +285,7 @@ class ObjectPermissionBackendTests(TestCase):
         ctype = ContentType.objects.create(name='foo', model='bar',
             app_label='fake-for-guardian-tests')
         perm = 'change_contenttype'
-        UserObjectPermission.objects.assign(perm, user, ctype)
+        UserObjectPermission.objects.assign_perm(perm, user, ctype)
         self.assertTrue(self.backend.has_perm(user, perm, ctype))
         user.is_active = False
         user.save()

--- a/guardian/tests/shortcuts_test.py
+++ b/guardian/tests/shortcuts_test.py
@@ -8,7 +8,7 @@ from guardian.shortcuts import get_perms_for_model
 from guardian.core import ObjectPermissionChecker
 from guardian.compat import get_user_model
 from guardian.compat import get_user_permission_full_codename
-from guardian.shortcuts import assign
+from guardian.shortcuts import assign_perm
 from guardian.shortcuts import remove_perm
 from guardian.shortcuts import get_perms
 from guardian.shortcuts import get_users_with_perms
@@ -42,41 +42,41 @@ class ShortcutsTests(ObjectPermissionTestCase):
             sorted(get_perms_for_model(model_str).values_list()),
             sorted(get_perms_for_model(obj).values_list()))
 
-class AssignTest(ObjectPermissionTestCase):
+class AssignPermTest(ObjectPermissionTestCase):
     """
     Tests permission assigning for user/group and object.
     """
     def test_not_model(self):
-        self.assertRaises(NotUserNorGroup, assign,
+        self.assertRaises(NotUserNorGroup, assign_perm,
             perm="change_object",
             user_or_group="Not a Model",
             obj=self.ctype)
 
     def test_global_wrong_perm(self):
-        self.assertRaises(ValueError, assign,
+        self.assertRaises(ValueError, assign_perm,
             perm="change_site", # for global permissions must provide app_label
             user_or_group=self.user)
 
-    def test_user_assign(self):
-        assign("change_contenttype", self.user, self.ctype)
-        assign("change_contenttype", self.group, self.ctype)
+    def test_user_assign_perm(self):
+        assign_perm("change_contenttype", self.user, self.ctype)
+        assign_perm("change_contenttype", self.group, self.ctype)
         self.assertTrue(self.user.has_perm("change_contenttype", self.ctype))
 
-    def test_group_assing(self):
-        assign("change_contenttype", self.group, self.ctype)
-        assign("delete_contenttype", self.group, self.ctype)
+    def test_group_assign_perm(self):
+        assign_perm("change_contenttype", self.group, self.ctype)
+        assign_perm("delete_contenttype", self.group, self.ctype)
 
         check = ObjectPermissionChecker(self.group)
         self.assertTrue(check.has_perm("change_contenttype", self.ctype))
         self.assertTrue(check.has_perm("delete_contenttype", self.ctype))
 
-    def test_user_assign_global(self):
-        perm = assign("contenttypes.change_contenttype", self.user)
+    def test_user_assign_perm_global(self):
+        perm = assign_perm("contenttypes.change_contenttype", self.user)
         self.assertTrue(self.user.has_perm("contenttypes.change_contenttype"))
         self.assertTrue(isinstance(perm, Permission))
 
-    def test_group_assing_global(self):
-        perm = assign("contenttypes.change_contenttype", self.group)
+    def test_group_assign_perm_global(self):
+        perm = assign_perm("contenttypes.change_contenttype", self.group)
 
         self.assertTrue(self.user.has_perm("contenttypes.change_contenttype"))
         self.assertTrue(isinstance(perm, Permission))
@@ -99,13 +99,13 @@ class RemovePermTest(ObjectPermissionTestCase):
 
     def test_user_remove_perm(self):
         # assign perm first
-        assign("change_contenttype", self.user, self.ctype)
+        assign_perm("change_contenttype", self.user, self.ctype)
         remove_perm("change_contenttype", self.user, self.ctype)
         self.assertFalse(self.user.has_perm("change_contenttype", self.ctype))
 
     def test_group_remove_perm(self):
         # assign perm first
-        assign("change_contenttype", self.group, self.ctype)
+        assign_perm("change_contenttype", self.group, self.ctype)
         remove_perm("change_contenttype", self.group, self.ctype)
 
         check = ObjectPermissionChecker(self.group)
@@ -114,14 +114,14 @@ class RemovePermTest(ObjectPermissionTestCase):
     def test_user_remove_perm_global(self):
         # assign perm first
         perm = "contenttypes.change_contenttype"
-        assign(perm, self.user)
+        assign_perm(perm, self.user)
         remove_perm(perm, self.user)
         self.assertFalse(self.user.has_perm(perm))
 
     def test_group_remove_perm_global(self):
         # assign perm first
         perm = "contenttypes.change_contenttype"
-        assign(perm, self.group)
+        assign_perm(perm, self.group)
         remove_perm(perm, self.group)
         app_label, codename = perm.split('.')
         perm_obj = Permission.objects.get(codename=codename,
@@ -143,7 +143,7 @@ class GetPermsTest(ObjectPermissionTestCase):
         perms_to_assign = ("change_contenttype",)
 
         for perm in perms_to_assign:
-            assign("change_contenttype", self.user, self.ctype)
+            assign_perm("change_contenttype", self.user, self.ctype)
 
         perms = get_perms(self.user, self.ctype)
         for perm in perms_to_assign:
@@ -175,9 +175,9 @@ class GetUsersWithPermsTest(TestCase):
         self.assertFalse(bool(result))
 
     def test_simple(self):
-        assign("change_contenttype", self.user1, self.obj1)
-        assign("delete_contenttype", self.user2, self.obj1)
-        assign("delete_contenttype", self.user3, self.obj2)
+        assign_perm("change_contenttype", self.user1, self.obj1)
+        assign_perm("delete_contenttype", self.user2, self.obj1)
+        assign_perm("delete_contenttype", self.user3, self.obj2)
 
         result = get_users_with_perms(self.obj1)
         result_vals = result.values_list('username', flat=True)
@@ -191,9 +191,9 @@ class GetUsersWithPermsTest(TestCase):
         self.user1.groups.add(self.group1)
         self.user2.groups.add(self.group2)
         self.user3.groups.add(self.group3)
-        assign("change_contenttype", self.group1, self.obj1)
-        assign("change_contenttype", self.group2, self.obj1)
-        assign("delete_contenttype", self.group3, self.obj2)
+        assign_perm("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.group2, self.obj1)
+        assign_perm("delete_contenttype", self.group3, self.obj2)
 
         result = get_users_with_perms(self.obj1).values_list('id',
             flat=True)
@@ -217,11 +217,11 @@ class GetUsersWithPermsTest(TestCase):
         self.user1.groups.add(self.group1)
         self.user2.groups.add(self.group2)
         self.user3.groups.add(self.group3)
-        assign("change_contenttype", self.group1, self.obj1)
-        assign("change_contenttype", self.group2, self.obj1)
-        assign("delete_contenttype", self.group3, self.obj2)
-        assign("delete_contenttype", self.user2, self.obj1)
-        assign("change_contenttype", self.user3, self.obj2)
+        assign_perm("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.group2, self.obj1)
+        assign_perm("delete_contenttype", self.group3, self.obj2)
+        assign_perm("delete_contenttype", self.user2, self.obj1)
+        assign_perm("change_contenttype", self.user3, self.obj2)
 
         # Check contenttype1
         result = get_users_with_perms(self.obj1, attach_perms=True)
@@ -244,19 +244,19 @@ class GetUsersWithPermsTest(TestCase):
 
     def test_attach_groups_only_has_perms(self):
         self.user1.groups.add(self.group1)
-        assign("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.group1, self.obj1)
         result = get_users_with_perms(self.obj1, attach_perms=True)
         expected = {self.user1: ["change_contenttype"]}
         self.assertEqual(result, expected)
 
     def test_mixed(self):
         self.user1.groups.add(self.group1)
-        assign("change_contenttype", self.group1, self.obj1)
-        assign("change_contenttype", self.user2, self.obj1)
-        assign("delete_contenttype", self.user2, self.obj1)
-        assign("delete_contenttype", self.user2, self.obj2)
-        assign("change_contenttype", self.user3, self.obj2)
-        assign("change_%s" % user_module_name, self.user3, self.user1)
+        assign_perm("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.user2, self.obj1)
+        assign_perm("delete_contenttype", self.user2, self.obj1)
+        assign_perm("delete_contenttype", self.user2, self.obj2)
+        assign_perm("change_contenttype", self.user3, self.obj2)
+        assign_perm("change_%s" % user_module_name, self.user3, self.user1)
 
         result = get_users_with_perms(self.obj1)
         self.assertEqual(
@@ -266,7 +266,7 @@ class GetUsersWithPermsTest(TestCase):
 
     def test_with_superusers(self):
         admin = User.objects.create(username='admin', is_superuser=True)
-        assign("change_contenttype", self.user1, self.obj1)
+        assign_perm("change_contenttype", self.user1, self.obj1)
 
         result = get_users_with_perms(self.obj1, with_superusers=True)
         self.assertEqual(
@@ -277,9 +277,9 @@ class GetUsersWithPermsTest(TestCase):
     def test_without_group_users(self):
         self.user1.groups.add(self.group1)
         self.user2.groups.add(self.group2)
-        assign("change_contenttype", self.group1, self.obj1)
-        assign("change_contenttype", self.user2, self.obj1)
-        assign("change_contenttype", self.group2, self.obj1)
+        assign_perm("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.user2, self.obj1)
+        assign_perm("change_contenttype", self.group2, self.obj1)
         result = get_users_with_perms(self.obj1, with_group_users=False)
         expected = set([self.user2])
         self.assertEqual(set(result), expected)
@@ -287,9 +287,9 @@ class GetUsersWithPermsTest(TestCase):
     def test_without_group_users_but_perms_attached(self):
         self.user1.groups.add(self.group1)
         self.user2.groups.add(self.group2)
-        assign("change_contenttype", self.group1, self.obj1)
-        assign("change_contenttype", self.user2, self.obj1)
-        assign("change_contenttype", self.group2, self.obj1)
+        assign_perm("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.user2, self.obj1)
+        assign_perm("change_contenttype", self.group2, self.obj1)
         result = get_users_with_perms(self.obj1, with_group_users=False,
             attach_perms=True)
         expected = {self.user2: ["change_contenttype"]}
@@ -297,7 +297,7 @@ class GetUsersWithPermsTest(TestCase):
 
     def test_without_group_users_no_result(self):
         self.user1.groups.add(self.group1)
-        assign("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.group1, self.obj1)
         result = get_users_with_perms(self.obj1, attach_perms=True,
                 with_group_users=False)
         expected = {}
@@ -306,7 +306,7 @@ class GetUsersWithPermsTest(TestCase):
     def test_without_group_users_no_result_but_with_superusers(self):
         admin = User.objects.create(username='admin', is_superuser=True)
         self.user1.groups.add(self.group1)
-        assign("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.group1, self.obj1)
         result = get_users_with_perms(self.obj1, with_group_users=False,
             with_superusers=True)
         expected = [admin]
@@ -339,7 +339,7 @@ class GetGroupsWithPerms(TestCase):
         self.assertFalse(bool(result))
 
     def test_simple(self):
-        assign("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.group1, self.obj1)
         result = get_groups_with_perms(self.obj1)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0], self.group1)
@@ -351,7 +351,7 @@ class GetGroupsWithPerms(TestCase):
         self.assertEqual(len(result), 0)
 
     def test_simple_attach_perms(self):
-        assign("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.group1, self.obj1)
         result = get_groups_with_perms(self.obj1, attach_perms=True)
         expected = {self.group1: ["change_contenttype"]}
         self.assertEqual(result, expected)
@@ -363,25 +363,25 @@ class GetGroupsWithPerms(TestCase):
         self.assertEqual(len(result), 0)
 
     def test_mixed(self):
-        assign("change_contenttype", self.group1, self.obj1)
-        assign("change_contenttype", self.group1, self.obj2)
-        assign("change_%s" % user_module_name, self.group1, self.user3)
-        assign("change_contenttype", self.group2, self.obj2)
-        assign("change_contenttype", self.group2, self.obj1)
-        assign("delete_contenttype", self.group2, self.obj1)
-        assign("change_%s" % user_module_name, self.group3, self.user1)
+        assign_perm("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.group1, self.obj2)
+        assign_perm("change_%s" % user_module_name, self.group1, self.user3)
+        assign_perm("change_contenttype", self.group2, self.obj2)
+        assign_perm("change_contenttype", self.group2, self.obj1)
+        assign_perm("delete_contenttype", self.group2, self.obj1)
+        assign_perm("change_%s" % user_module_name, self.group3, self.user1)
 
         result = get_groups_with_perms(self.obj1)
         self.assertEqual(set(result), set([self.group1, self.group2]))
 
     def test_mixed_attach_perms(self):
-        assign("change_contenttype", self.group1, self.obj1)
-        assign("change_contenttype", self.group1, self.obj2)
-        assign("change_group", self.group1, self.group3)
-        assign("change_contenttype", self.group2, self.obj2)
-        assign("change_contenttype", self.group2, self.obj1)
-        assign("delete_contenttype", self.group2, self.obj1)
-        assign("change_group", self.group3, self.group1)
+        assign_perm("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.group1, self.obj2)
+        assign_perm("change_group", self.group1, self.group3)
+        assign_perm("change_contenttype", self.group2, self.obj2)
+        assign_perm("change_contenttype", self.group2, self.obj1)
+        assign_perm("delete_contenttype", self.group2, self.obj1)
+        assign_perm("change_group", self.group3, self.group1)
 
         result = get_groups_with_perms(self.obj1, attach_perms=True)
         expected = {
@@ -440,26 +440,26 @@ class GetObjectsForUser(TestCase):
 
     def test_perms_single(self):
         perm = 'auth.change_group'
-        assign(perm, self.user, self.group)
+        assign_perm(perm, self.user, self.group)
         self.assertEqual(
             set(get_objects_for_user(self.user, perm)),
             set(get_objects_for_user(self.user, [perm])))
 
     def test_klass_as_model(self):
-        assign('contenttypes.change_contenttype', self.user, self.ctype)
+        assign_perm('contenttypes.change_contenttype', self.user, self.ctype)
 
         objects = get_objects_for_user(self.user,
             ['contenttypes.change_contenttype'], ContentType)
         self.assertEqual([obj.name for obj in objects], [self.ctype.name])
 
     def test_klass_as_manager(self):
-        assign('auth.change_group', self.user, self.group)
+        assign_perm('auth.change_group', self.user, self.group)
         objects = get_objects_for_user(self.user, ['auth.change_group'],
             Group.objects)
         self.assertEqual([obj.name for obj in objects], [self.group.name])
 
     def test_klass_as_queryset(self):
-        assign('auth.change_group', self.user, self.group)
+        assign_perm('auth.change_group', self.user, self.group)
         objects = get_objects_for_user(self.user, ['auth.change_group'],
             Group.objects.all())
         self.assertEqual([obj.name for obj in objects], [self.group.name])
@@ -472,7 +472,7 @@ class GetObjectsForUser(TestCase):
         group_names = ['group1', 'group2', 'group3']
         groups = [Group.objects.create(name=name) for name in group_names]
         for group in groups:
-            assign('change_group', self.user, group)
+            assign_perm('change_group', self.user, group)
 
         objects = get_objects_for_user(self.user, ['auth.change_group'])
         self.assertEqual(len(objects), len(groups))
@@ -485,8 +485,8 @@ class GetObjectsForUser(TestCase):
         group_names = ['group1', 'group2', 'group3']
         groups = [Group.objects.create(name=name) for name in group_names]
         for group in groups:
-            assign('auth.change_group', self.user, group)
-        assign('auth.delete_group', self.user, groups[1])
+            assign_perm('auth.change_group', self.user, group)
+        assign_perm('auth.delete_group', self.user, groups[1])
 
         objects = get_objects_for_user(self.user, ['auth.change_group',
             'auth.delete_group'])
@@ -499,8 +499,8 @@ class GetObjectsForUser(TestCase):
     def test_any_of_multiple_perms_to_check(self):
         group_names = ['group1', 'group2', 'group3']
         groups = [Group.objects.create(name=name) for name in group_names]
-        assign('auth.change_group', self.user, groups[0])
-        assign('auth.delete_group', self.user, groups[2])
+        assign_perm('auth.change_group', self.user, groups[0])
+        assign_perm('auth.delete_group', self.user, groups[2])
 
         objects = get_objects_for_user(self.user, ['auth.change_group',
             'auth.delete_group'], any_perm=True)
@@ -521,15 +521,15 @@ class GetObjectsForUser(TestCase):
         # Objects to operate on
         ctypes = dict(((ct.id, ct) for ct in ContentType.objects.all()))
 
-        assign('change_contenttype', self.user, ctypes[1])
-        assign('change_contenttype', self.user, ctypes[2])
-        assign('delete_contenttype', self.user, ctypes[2])
-        assign('delete_contenttype', self.user, ctypes[3])
+        assign_perm('change_contenttype', self.user, ctypes[1])
+        assign_perm('change_contenttype', self.user, ctypes[2])
+        assign_perm('delete_contenttype', self.user, ctypes[2])
+        assign_perm('delete_contenttype', self.user, ctypes[3])
 
-        assign('change_contenttype', groups[0], ctypes[4])
-        assign('change_contenttype', groups[1], ctypes[4])
-        assign('change_contenttype', groups[2], ctypes[5])
-        assign('delete_contenttype', groups[0], ctypes[1])
+        assign_perm('change_contenttype', groups[0], ctypes[4])
+        assign_perm('change_contenttype', groups[1], ctypes[4])
+        assign_perm('change_contenttype', groups[2], ctypes[5])
+        assign_perm('delete_contenttype', groups[0], ctypes[1])
 
         objects = get_objects_for_user(self.user,
             ['contenttypes.change_contenttype'])
@@ -600,27 +600,27 @@ class GetObjectsForGroup(TestCase):
 
     def test_perms_single(self):
         perm = 'contenttypes.change_contenttype'
-        assign(perm, self.group1, self.obj1)
+        assign_perm(perm, self.group1, self.obj1)
         self.assertEqual(
             set(get_objects_for_group(self.group1, perm)),
             set(get_objects_for_group(self.group1, [perm]))
         )
 
     def test_klass_as_model(self):
-        assign('contenttypes.change_contenttype', self.group1, self.obj1)
+        assign_perm('contenttypes.change_contenttype', self.group1, self.obj1)
 
         objects = get_objects_for_group(self.group1,
             ['contenttypes.change_contenttype'], ContentType)
         self.assertEqual([obj.name for obj in objects], [self.obj1.name])
 
     def test_klass_as_manager(self):
-        assign('contenttypes.change_contenttype', self.group1, self.obj1)
+        assign_perm('contenttypes.change_contenttype', self.group1, self.obj1)
         objects = get_objects_for_group(self.group1, ['change_contenttype'],
             ContentType.objects)
         self.assertEqual(list(objects), [self.obj1])
 
     def test_klass_as_queryset(self):
-        assign('contenttypes.change_contenttype', self.group1, self.obj1)
+        assign_perm('contenttypes.change_contenttype', self.group1, self.obj1)
         objects = get_objects_for_group(self.group1, ['change_contenttype'],
             ContentType.objects.all())
         self.assertEqual(list(objects), [self.obj1])
@@ -630,8 +630,8 @@ class GetObjectsForGroup(TestCase):
         self.assertTrue(isinstance(objects, QuerySet))
 
     def test_simple(self):
-        assign('change_contenttype', self.group1, self.obj1)
-        assign('change_contenttype', self.group1, self.obj2)
+        assign_perm('change_contenttype', self.group1, self.obj1)
+        assign_perm('change_contenttype', self.group1, self.obj2)
 
         objects = get_objects_for_group(self.group1, 'contenttypes.change_contenttype')
         self.assertEqual(len(objects), 2)
@@ -648,9 +648,9 @@ class GetObjectsForGroup(TestCase):
         self.assertEqual(objects[0], self.obj2)
 
     def test_multiple_perms_to_check(self):
-        assign('change_contenttype', self.group1, self.obj1)
-        assign('delete_contenttype', self.group1, self.obj1)
-        assign('change_contenttype', self.group1, self.obj2)
+        assign_perm('change_contenttype', self.group1, self.obj1)
+        assign_perm('delete_contenttype', self.group1, self.obj1)
+        assign_perm('change_contenttype', self.group1, self.obj2)
 
         objects = get_objects_for_group(self.group1, [
             'contenttypes.change_contenttype',
@@ -660,10 +660,10 @@ class GetObjectsForGroup(TestCase):
         self.assertEqual(objects[0], self.obj1)
 
     def test_any_of_multiple_perms_to_check(self):
-        assign('change_contenttype', self.group1, self.obj1)
-        assign('delete_contenttype', self.group1, self.obj1)
-        assign('add_contenttype', self.group1, self.obj2)
-        assign('delete_contenttype', self.group1, self.obj3)
+        assign_perm('change_contenttype', self.group1, self.obj1)
+        assign_perm('delete_contenttype', self.group1, self.obj1)
+        assign_perm('add_contenttype', self.group1, self.obj2)
+        assign_perm('delete_contenttype', self.group1, self.obj3)
 
         objects = get_objects_for_group(self.group1,
             ['contenttypes.change_contenttype',
@@ -673,8 +673,8 @@ class GetObjectsForGroup(TestCase):
             [self.obj1, self.obj3])
 
     def test_results_for_different_groups_are_correct(self):
-        assign('change_contenttype', self.group1, self.obj1)
-        assign('delete_contenttype', self.group2, self.obj2)
+        assign_perm('change_contenttype', self.group1, self.obj1)
+        assign_perm('delete_contenttype', self.group2, self.obj2)
 
         self.assertEqual(set(get_objects_for_group(self.group1, 'contenttypes.change_contenttype')),
             set([self.obj1]))

--- a/guardian/tests/tags_test.py
+++ b/guardian/tests/tags_test.py
@@ -90,9 +90,9 @@ class GetObjPermsTagTest(TestCase):
             self.assertTrue(perm in output)
 
     def test_user(self):
-        UserObjectPermission.objects.assign("change_contenttype", self.user,
+        UserObjectPermission.objects.assign_perm("change_contenttype", self.user,
             self.ctype)
-        GroupObjectPermission.objects.assign("delete_contenttype", self.group,
+        GroupObjectPermission.objects.assign_perm("delete_contenttype", self.group,
             self.ctype)
 
         template = ''.join((
@@ -108,7 +108,7 @@ class GetObjPermsTagTest(TestCase):
             set('change_contenttype delete_contenttype'.split(' ')))
 
     def test_group(self):
-        GroupObjectPermission.objects.assign("delete_contenttype", self.group,
+        GroupObjectPermission.objects.assign_perm("delete_contenttype", self.group,
             self.ctype)
 
         template = ''.join((


### PR DESCRIPTION
Backward compatible but a depreciation warning is thrown. Also updated '.gitingore' to ignore WebDAV cache files.
