### PR TITLE
Speed up get_perms

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Authors ordered by first contribution
 - Aram Dulyan <aram@dulyan.com>
 - Florian Hahn <flo@fhahn.com>
 - Piotr Kilczuk <piotr@tymaszweb.pl>
+- Reavis Sutphin-Gray <reavis@sutphin-gray.com>

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -101,11 +101,14 @@ class ObjectPermissionChecker(object):
                     })
                 else:
                     user_filters['%s__content_object' % related_name] = obj
-
-                perms = list(set(chain(*Permission.objects
-                    .filter(content_type=ctype)
-                    .filter(Q(**user_filters) | Q(**group_filters))
-                    .values_list("codename"))))
+                perms_qs = Permission.objects.filter(content_type=ctype)
+                # Query user and group permissions separately and then combine
+                # the results to avoid a slow query
+                user_perms_qs = perms_qs.filter(**user_filters)
+                user_perms = user_perms_qs.values_list("codename", flat=True)
+                group_perms_qs = perms_qs.filter(**group_filters)
+                group_perms = group_perms_qs.values_list("codename", flat=True)
+                perms = list(set(chain(user_perms, group_perms)))
             else:
                 perms = list(set(chain(*Permission.objects
                     .filter(content_type=ctype)

--- a/guardian/tests/core_test.py
+++ b/guardian/tests/core_test.py
@@ -44,13 +44,13 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
             ContentType.objects.clear_cache()
             checker = ObjectPermissionChecker(self.user)
 
-            # has_perm on Checker should spawn only one query plus one extra
+            # has_perm on Checker should spawn only two queries plus one extra
             # for fetching the content type first time we check for specific
             # model and two more content types as there are additional checks
             # at get_user_obj_perms_model and get_group_obj_perms_model
             query_count = len(connection.queries)
             res = checker.has_perm("change_group", self.group)
-            self.assertEqual(len(connection.queries), query_count + 4)
+            self.assertEqual(len(connection.queries), query_count + 5)
 
             # Checking again shouldn't spawn any queries
             query_count = len(connection.queries)
@@ -64,17 +64,17 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
             checker.has_perm("delete_group", self.group)
             self.assertEqual(len(connection.queries), query_count)
 
-            # Checking for same model but other instance should spawn 1 query
+            # Checking for same model but other instance should spawn 2 queries
             new_group = Group.objects.create(name='new-group')
             query_count = len(connection.queries)
             checker.has_perm("change_group", new_group)
-            self.assertEqual(len(connection.queries), query_count + 1)
+            self.assertEqual(len(connection.queries), query_count + 2)
 
             # Checking for permission for other model should spawn 3 queries
             # (again: content type and actual permissions for the object...
             query_count = len(connection.queries)
             checker.has_perm("change_user", self.user)
-            self.assertEqual(len(connection.queries), query_count + 2)
+            self.assertEqual(len(connection.queries), query_count + 3)
 
         finally:
             settings.DEBUG = False


### PR DESCRIPTION
Split a single large permissions query into multiple queries to improve
performance
