### PR TITLE
GuardedModelAdmin patch for supporting USERNAME_FIELD

### DIFF
--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -377,7 +377,7 @@ class UserManage(forms.Form):
     user = forms.CharField(label=_("User identification"), 
                         max_length=200,
                         error_messages = {'does_not_exist': _("This user does not exist")},
-                        help_text=_('The search is based on User.USERNAME_FIELD')
+                        help_text=_('Enter a value compatible with User.USERNAME_FIELD')
                      )
 
     def clean_user(self):
@@ -393,7 +393,7 @@ class UserManage(forms.Form):
             return user
         except user_model.DoesNotExist:
             raise forms.ValidationError(
-                self.fields['identification'].error_messages['does_not_exist'])
+                self.fields['user'].error_messages['does_not_exist'])
 
 
 class GroupManage(forms.Form):


### PR DESCRIPTION
Hi there, 

I'm using a custom User (Django 1.5) and there is no 'username' field there.
GuardedModelAdmin depends on the 'username' for connecting users to objects in admin.
This patch allows the administrator to search the users by what's defined in USERNAME_FIELD
Thank you for this great app.
