### PR TITLE
Fixed  Issue #164: Shortcuts: get_objects_for_user() is incompatible with Django 1.6

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -395,7 +395,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
         group_filters = {
             'permission__content_type': ctype,
             'permission__codename__in': codenames,
-            'group__%s' % get_user_model()._meta.module_name: user,
+            'group__%s' % get_user_model().groups.field.related_query_name(): user,
         }
         groups_obj_perms_queryset = group_model.objects.filter(**group_filters)
         if group_model.objects.is_generic():


### PR DESCRIPTION
Fixed https://github.com/lukaszb/django-guardian/issues/164
