### PR TITLE
add accept_global_perms into PermissionRequiredMixin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Authors ordered by first contribution
 - John P. Neumann <arrantsquid@gmail.com>
 - Andreas Madsack <andreas@madflex.de>
 - Ivan Kharlamov <the.paper.men@gmail.com>
+- Jan Nakladal <mojeto1@gmail.com>

--- a/guardian/mixins.py
+++ b/guardian/mixins.py
@@ -108,10 +108,12 @@ class PermissionRequiredMixin(object):
 
         `permission_required` - the permission to check of form "<app_label>.<permission codename>"
                                 i.e. 'polls.can_vote' for a permission on a model in the polls application.
+
     ``PermissionRequiredMixin.accept_global_perms``
 
-        *Default*: ``False``, if set to ``True``, then *object level
-        permission* would be required
+        *Default*: ``False``,  If accept_global_perms would be set to True, then
+         mixing would first check for global perms, if none found, then it will
+         proceed to check object level permissions.
 
     """
     ### default class view settings


### PR DESCRIPTION
Hello, I would like use PermissionRequiredMixin with global permission like permission_required decorator does.

This is my first commit and first pull request so let me know if I do something wrong.
