### PR TITLE
UserObjectPermissionManager.get_for_object return queryset based on object

### DIFF
--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -72,11 +72,18 @@ class UserObjectPermissionManager(BaseObjectPermissionManager):
         if getattr(obj, 'pk', None) is None:
             raise ObjectNotPersisted("Object %s needs to be persisted first"
                 % obj)
-        ctype = ContentType.objects.get_for_model(obj)
-        perms = self.filter(
-            content_type = ctype,
-            user = user,
-        )
+        if self.is_generic():
+            ctype = ContentType.objects.get_for_model(obj)
+            perms = self.filter(
+                content_type = ctype,
+                user = user,
+                object_pk = obj.pk
+            )
+        else:
+            perms = self.filter(
+                content_object=obj,
+                user = user
+            )
         return perms
 
 
@@ -130,10 +137,17 @@ class GroupObjectPermissionManager(BaseObjectPermissionManager):
         if getattr(obj, 'pk', None) is None:
             raise ObjectNotPersisted("Object %s needs to be persisted first"
                 % obj)
-        ctype = ContentType.objects.get_for_model(obj)
-        perms = self.filter(
-            content_type = ctype,
-            group = group,
-        )
+        if self.is_generic():
+            ctype = ContentType.objects.get_for_model(obj)
+            perms = self.filter(
+                content_type = ctype,
+                group = group,
+                object_pk = obj.pk
+            )
+        else:
+            perms = self.filter(
+                content_object=obj,
+                group = group
+            )
         return perms
 

--- a/guardian/tests/other_test.py
+++ b/guardian/tests/other_test.py
@@ -22,6 +22,7 @@ from guardian.exceptions import WrongAppError
 from guardian.models import GroupObjectPermission
 from guardian.models import UserObjectPermission
 from guardian.tests.conf import TestDataMixin
+from .testapp.models import Project
 
 User = get_user_model()
 user_model_path = get_user_model_path()
@@ -78,18 +79,23 @@ class UserPermissionTests(TestDataMixin, TestCase):
         self.assertFalse(self.user.has_perm('change_contenttype', self.obj1))
 
     def test_get_for_object(self):
-        perms = UserObjectPermission.objects.get_for_object(self.user, self.ctype)
+        obj1 = Project.objects.create(name="Foobar")
+        obj2 = Project.objects.create(name="Foobaz")
+        perms = UserObjectPermission.objects.get_for_object(self.user, obj1)
         self.assertEqual(perms.count(), 0)
 
         to_assign = sorted([
-            'delete_contenttype',
-            'change_contenttype',
+            'delete_project',
+            'change_project',
         ])
 
         for perm in to_assign:
-            UserObjectPermission.objects.assign_perm(perm, self.user, self.ctype)
+            UserObjectPermission.objects.assign_perm(perm, self.user, obj1)
 
-        perms = UserObjectPermission.objects.get_for_object(self.user, self.ctype)
+        for perm in to_assign:
+            UserObjectPermission.objects.assign_perm(perm, self.user, obj2)
+
+        perms = UserObjectPermission.objects.get_for_object(self.user, obj1)
         codenames = sorted(chain(*perms.values_list('permission__codename')))
 
         self.assertEqual(to_assign, codenames)
@@ -194,21 +200,26 @@ class GroupPermissionTests(TestDataMixin, TestCase):
         self.assertFalse(self.user.has_perm('change_contenttype', self.obj1))
 
     def test_get_for_object(self):
+        obj1 = Project.objects.create(name="Foobar")
+        obj2 = Project.objects.create(name='Foobaz')
         group = Group.objects.create(name='get_group_perms_for_object')
         self.user.groups.add(group)
 
-        perms = GroupObjectPermission.objects.get_for_object(group, self.ctype)
+        perms = GroupObjectPermission.objects.get_for_object(group, obj1)
         self.assertEqual(perms.count(), 0)
 
         to_assign = sorted([
-            'delete_contenttype',
-            'change_contenttype',
+            'delete_project',
+            'change_project',
         ])
 
         for perm in to_assign:
-            GroupObjectPermission.objects.assign_perm(perm, group, self.ctype)
+            GroupObjectPermission.objects.assign_perm(perm, group, obj1)
 
-        perms = GroupObjectPermission.objects.get_for_object(group, self.ctype)
+        for perm in to_assign:
+            GroupObjectPermission.objects.assign_perm(perm, group, obj2)
+
+        perms = GroupObjectPermission.objects.get_for_object(group, obj1)
         codenames = sorted(chain(*perms.values_list('permission__codename')))
 
         self.assertEqual(to_assign, codenames)


### PR DESCRIPTION
get_for_object method in UserObjectPermissionManager and GroupObjectPermissionManager was filtering only on content type and user/group. that make query for model not for object.
I changed it to add filtering with object pk, too.
