### PR TITLE
Add with_superuser flag to get_objects_for_user shortcut

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -283,7 +283,8 @@ def get_groups_with_perms(obj, attach_perms=False):
                 groups[group] = sorted(get_perms(group, obj))
         return groups
 
-def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=False):
+def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=False,
+        with_superuser=True):
     """
     Returns queryset of objects for which a given ``user`` has *all*
     permissions present at ``perms``.
@@ -301,7 +302,9 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
     :param use_groups: if ``False``, wouldn't check user's groups object
       permissions. Default is ``True``.
     :param any_perm: if True, any of permission in sequence is accepted
-
+    :param with_superuser: if ``True`` returns the entire queryset if not it will
+    only return objects the user has explicit permissions.
+    
     :raises MixedContentTypeError: when computed content type for ``perms``
       and/or ``klass`` clashes.
     :raises WrongAppError: if cannot compute app label for given ``perms``/
@@ -377,7 +380,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
     # we should also have ``codenames`` list
 
     # First check if user is superuser and if so, return queryset immediately
-    if user.is_superuser:
+    if with_superuser and user.is_superuser:
         return queryset
 
     # Check if the user is anonymous. The

--- a/guardian/testapp/tests/shortcuts_test.py
+++ b/guardian/testapp/tests/shortcuts_test.py
@@ -420,6 +420,23 @@ class GetObjectsForUser(TestCase):
             ['contenttypes.change_contenttype'], ctypes)
         self.assertEqual(set(ctypes), set(objects))
 
+    def test_with_superuser_true(self):
+        self.user.is_superuser = True
+        ctypes = ContentType.objects.all()
+        objects = get_objects_for_user(self.user,
+            ['contenttypes.change_contenttype'], ctypes, with_superuser=True)
+        self.assertEqual(set(ctypes), set(objects))
+
+    def test_with_superuser_false(self):
+        self.user.is_superuser = True
+        ctypes = ContentType.objects.all()
+        obj1 = ContentType.objects.create(name='ct1', model='foo',
+            app_label='guardian-tests')
+        assign_perm('change_contenttype', self.user, obj1)
+        objects = get_objects_for_user(self.user,
+            ['contenttypes.change_contenttype'], ctypes, with_superuser=False)
+        self.assertEqual(set([obj1]), set(objects))
+
     def test_anonymous(self):
         self.user = AnonymousUser()
         ctypes = ContentType.objects.all()


### PR DESCRIPTION
It would be nice to have this feature merged, since for some cases we would like to list only the objects set to the given superuser, without having to list every object in the system, because the superuser account can be used as a regular account.

Thanks!
