### PR TITLE
Update django-grappelli repository url.

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -39,7 +39,7 @@ version of Django_. For instance, there are great `django-authority`_ or
 .. _django-authority: http://bitbucket.org/jezdez/django-authority/
 .. _django-permissions: http://bitbucket.org/diefenbach/django-permissions/
 .. _issue-tracker: http://github.com/lukaszb/django-guardian
-.. _grappelli: http://code.google.com/p/django-grappelli/
+.. _grappelli: https://github.com/sehmaschine/django-grappelli
 
 .. [1] See http://docs.djangoproject.com/en/1.2/topics/auth/#handling-object-permissions
    for more detail.


### PR DESCRIPTION
`django-grappelli` repository has been moved from http://code.google.com/p/django-grappelli/ to https://github.com/sehmaschine/django-grappelli
