### PR TITLE
Update the initial migration to handle custom user model with a set db_table

### DIFF
--- a/guardian/migrations/0001_initial.py
+++ b/guardian/migrations/0001_initial.py
@@ -2,7 +2,8 @@
 from south.db import db
 from south.v2 import SchemaMigration
 
-from guardian.compat import user_model_label, get_user_model
+from guardian.compat import user_model_label
+from guardian.compat import get_user_model
 
 User = get_user_model()
 


### PR DESCRIPTION
If a project has a custom user model with the `db_table` set in the `Meta` class, then the initial migration will fail. This updates the initial migration to work under that situation.
