### PR TITLE
Simplify app_label checking

### DIFF
--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -54,7 +54,7 @@ class ObjectPermissionBackend(object):
         if not user_obj.is_active:
             return False
 
-        if len(perm.split('.')) > 1:
+        if '.' in perm > 1:
             app_label, perm = perm.split('.')
             if app_label != obj._meta.app_label:
                 raise WrongAppError("Passed perm has app label of '%s' and "


### PR DESCRIPTION
No need to create an interim tuple just to check whether or not a period is present in the permission name. This uses unnecessary memory and garbage collector time.
