### PR TITLE
Fixed migrations to allow custom user models

### DIFF
--- a/guardian/migrations/0001_initial.py
+++ b/guardian/migrations/0001_initial.py
@@ -7,6 +7,13 @@ from guardian.compat import get_user_model
 
 User = get_user_model()
 
+def get_user_pk_field_fully_qualified_name():
+    pk_field = User._meta.pk
+    module = pk_field.__class__.__module__
+    if module is None:
+        return pk_field.__class__.__name__
+    return module + '.' + pk_field.__class__.__name__
+
 
 class Migration(SchemaMigration):
 
@@ -70,19 +77,11 @@ class Migration(SchemaMigration):
         },
         user_model_label: {
             'Meta': {'object_name': user_model_label.split('.')[-1], 'db_table': "'%s'" % User._meta.db_table},
-            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
-            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
-            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
-            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+            User._meta.pk.attname: (
+                get_user_pk_field_fully_qualified_name(), [],
+                {'primary_key': 'True',
+                'db_column': "'%s'" % User._meta.pk.column}
+            ),
         },
         'contenttypes.contenttype': {
             'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},

--- a/guardian/migrations/0002_auto__add_field_groupobjectpermission_object_pk__add_field_userobjectp.py
+++ b/guardian/migrations/0002_auto__add_field_groupobjectpermission_object_pk__add_field_userobjectp.py
@@ -3,6 +3,16 @@ from south.db import db
 from south.v2 import SchemaMigration
 
 from guardian.compat import user_model_label
+from guardian.compat import get_user_model
+
+User = get_user_model()
+
+def get_user_pk_field_fully_qualified_name():
+    pk_field = User._meta.pk
+    module = pk_field.__class__.__module__
+    if module is None:
+        return pk_field.__class__.__name__
+    return module + '.' + pk_field.__class__.__name__
 
 
 class Migration(SchemaMigration):
@@ -40,20 +50,12 @@ class Migration(SchemaMigration):
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         },
         user_model_label: {
-            'Meta': {'object_name': user_model_label.split('.')[-1]},
-            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
-            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
-            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
-            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+            'Meta': {'object_name': user_model_label.split('.')[-1], 'db_table': "'%s'" % User._meta.db_table},
+            User._meta.pk.attname: (
+                get_user_pk_field_fully_qualified_name(), [],
+                {'primary_key': 'True',
+                'db_column': "'%s'" % User._meta.pk.column}
+            ),
         },
         'contenttypes.contenttype': {
             'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},

--- a/guardian/migrations/0003_update_objectpermission_object_pk.py
+++ b/guardian/migrations/0003_update_objectpermission_object_pk.py
@@ -2,6 +2,16 @@
 from south.v2 import DataMigration
 
 from guardian.compat import user_model_label
+from guardian.compat import get_user_model
+
+User = get_user_model()
+
+def get_user_pk_field_fully_qualified_name():
+    pk_field = User._meta.pk
+    module = pk_field.__class__.__module__
+    if module is None:
+        return pk_field.__class__.__name__
+    return module + '.' + pk_field.__class__.__name__
 
 
 class Migration(DataMigration):
@@ -41,20 +51,12 @@ class Migration(DataMigration):
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         },
         user_model_label: {
-            'Meta': {'object_name': user_model_label.split('.')[-1]},
-            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
-            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
-            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
-            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+            'Meta': {'object_name': user_model_label.split('.')[-1], 'db_table': "'%s'" % User._meta.db_table},
+            User._meta.pk.attname: (
+                get_user_pk_field_fully_qualified_name(), [],
+                {'primary_key': 'True',
+                'db_column': "'%s'" % User._meta.pk.column}
+            ),
         },
         'contenttypes.contenttype': {
             'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},

--- a/guardian/migrations/0004_auto__del_field_groupobjectpermission_object_id__del_unique_groupobjec.py
+++ b/guardian/migrations/0004_auto__del_field_groupobjectpermission_object_id__del_unique_groupobjec.py
@@ -3,6 +3,16 @@ from south.db import db
 from south.v2 import SchemaMigration
 
 from guardian.compat import user_model_label
+from guardian.compat import get_user_model
+
+User = get_user_model()
+
+def get_user_pk_field_fully_qualified_name():
+    pk_field = User._meta.pk
+    module = pk_field.__class__.__module__
+    if module is None:
+        return pk_field.__class__.__name__
+    return module + '.' + pk_field.__class__.__name__
 
 
 class Migration(SchemaMigration):
@@ -64,20 +74,12 @@ class Migration(SchemaMigration):
             'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
         },
         user_model_label: {
-            'Meta': {'object_name': user_model_label.split('.')[-1]},
-            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
-            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
-            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
-            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
-            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
-            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
-            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
-            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+            'Meta': {'object_name': user_model_label.split('.')[-1], 'db_table': "'%s'" % User._meta.db_table},
+            User._meta.pk.attname: (
+                get_user_pk_field_fully_qualified_name(), [],
+                {'primary_key': 'True',
+                'db_column': "'%s'" % User._meta.pk.column}
+            ),
         },
         'contenttypes.contenttype': {
             'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},

--- a/guardian/migrations/0005_auto__chg_field_groupobjectpermission_object_pk__chg_field_userobjectp.py
+++ b/guardian/migrations/0005_auto__chg_field_groupobjectpermission_object_pk__chg_field_userobjectp.py
@@ -3,6 +3,16 @@ from south.db import db
 from south.v2 import SchemaMigration
 
 from guardian.compat import user_model_label
+from guardian.compat import get_user_model
+
+User = get_user_model()
+
+def get_user_pk_field_fully_qualified_name():
+    pk_field = User._meta.pk
+    module = pk_field.__class__.__module__
+    if module is None:
+        return pk_field.__class__.__name__
+    return module + '.' + pk_field.__class__.__name__
 
 
 class Migration(SchemaMigration):


### PR DESCRIPTION
The migrations now allow custom user models to be used with custom (non-integer) primary key fields.
We tested them and they work.
Sorry about the code duplication but I did not find a module where ```get_user_pk_field_fully_qualified_name()``` should be.
Maybe in compat.py?

Please merge and release :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/lukaszb/django-guardian/241)
<!-- Reviewable:end -->
