### PR TITLE
RemovedInDjango18Warning: `GuardedModelAdminMixin.queryset` method shoul...

### DIFF
--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -60,7 +60,7 @@ class GuardedModelAdminMixin(object):
     group_owned_objects_field = 'group'
     include_object_permissions_urls = True
 
-    def queryset(self, request):
+    def get_queryset(self, request):
         qs = super(GuardedModelAdminMixin, self).queryset(request)
         if request.user.is_superuser:
             return qs


### PR DESCRIPTION
...d be renamed `get_queryset`.

Updating def queryset to def get_queryset to silence warning under Django 1.7's system check framework.
