### PR TITLE
 PermissionRequiredMixin: configurability

### DIFF
--- a/guardian/mixins.py
+++ b/guardian/mixins.py
@@ -131,7 +131,7 @@ class PermissionRequiredMixin(object):
     return_403 = False
     raise_exception = False
     accept_global_perms = False
-    permission_object=None
+    permission_object = None
     def get_required_permissions(self, request=None):
         """
         Returns list of permissions in format *<app_label>.<codename>* that
@@ -152,7 +152,8 @@ class PermissionRequiredMixin(object):
         return perms
     
     def get_permission_object(self):
-        if self.permission_object:return self.permission_object
+        if self.permission_object:
+            return self.permission_object
         return (hasattr(self, 'get_object') and self.get_object()
                 or getattr(self, 'object', None))
                 


### PR DESCRIPTION
The check_permissions() method was using object, that is okay, but in case the ability to do something on a model rely on possessing some permission on another model that would result hard to deal with.
I think it's better to have another method to retrieve the permission object so that changing this behavior would not require the complete creation of another children mixin with the copy-paste of check_permission method
