### PR TITLE
Cached the object permissions models in order to save queries

### DIFF
--- a/guardian/testapp/tests/core_test.py
+++ b/guardian/testapp/tests/core_test.py
@@ -60,7 +60,7 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
             query_count = len(connection.queries)
             res = checker.has_perm("change_group", self.group)
             if 'guardian.testapp' in settings.INSTALLED_APPS:
-                expected = 5
+                expected = 3
             else:
                 # TODO: This is strange, need to investigate; totally not sure
                 # why there are more queries if testapp is not included

--- a/guardian/testapp/tests/utils_test.py
+++ b/guardian/testapp/tests/utils_test.py
@@ -56,7 +56,7 @@ class GetIdentityTest(ObjectPermissionTestCase):
 
 
 @skipUnlessTestApp
-class GetUserObjPermsModelTest(TestCase):
+class GetUserObjPermsModelTest(ObjectPermissionTestCase):
 
     def test_for_instance(self):
         project = Project(name='Foobar')
@@ -96,7 +96,7 @@ class GetUserObjPermsModelTest(TestCase):
 
 
 @skipUnlessTestApp
-class GetGroupObjPermsModelTest(TestCase):
+class GetGroupObjPermsModelTest(ObjectPermissionTestCase):
 
     def test_for_instance(self):
         project = Project(name='Foobar')


### PR DESCRIPTION
I noticed that guardian performs extra queries when they are not needed.
Caching them in process is probably a good idea.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/lukaszb/django-guardian/295)

<!-- Reviewable:end -->
