### PR TITLE
global perms carry over in has_perm, fixes #294

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,3 +54,4 @@ Authors ordered by first contribution
 - Verena Jaspersen <verena.jaspersen@gmail.com>
 - Bertrand Svetchine <bertrand.svetchine@gmail.com>
 - Frank Wickström <frank@bambuser.com>
+- David Filipovic <david.filipovic@gmail.com>

--- a/guardian/conf/settings.py
+++ b/guardian/conf/settings.py
@@ -17,6 +17,8 @@ TEMPLATE_403 = getattr(settings, 'GUARDIAN_TEMPLATE_403', '403.html')
 RAISE_403 = getattr(settings, 'GUARDIAN_RAISE_403', False)
 GET_INIT_ANONYMOUS_USER = getattr(settings, 'GUARDIAN_GET_INIT_ANONYMOUS_USER',
     'guardian.management.get_init_anonymous_user')
+GLOBAL_PERMISSIONS_CARRY_OVER = getattr(settings, 'GUARDIAN_GLOBAL_PERMISSIONS_CARRY_OVER',
+    False)
 
 MONKEY_PATCH = getattr(settings, 'GUARDIAN_MONKEY_PATCH', True)
 

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -9,6 +9,8 @@ from guardian.conf import settings
 from guardian.utils import get_identity
 from guardian.utils import get_user_obj_perms_model
 from guardian.utils import get_group_obj_perms_model
+from guardian.utils import group_has_perm
+from guardian.utils import get_qualified_perm
 from guardian.compat import get_user_model
 
 
@@ -47,11 +49,7 @@ class ObjectPermissionChecker(object):
         :param obj: Django model instance for which permission should be checked
 
         """
-        if '.' in perm:
-            qualified_perm = perm
-        else:
-            qualified_perm = '%s.%s' % (obj._meta.app_label, perm)
-
+        qualified_perm = get_qualified_perm(perm, obj)
         perm = perm.split('.')[-1]
         if self.user and not self.user.is_active:
             return False
@@ -64,6 +62,10 @@ class ObjectPermissionChecker(object):
                 self.user
                 and
                 self.user.has_perm(qualified_perm)
+            ) or (
+                self.group
+                and
+                group_has_perm(self.group, qualified_perm)
             )
 
         return has_perm

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -46,12 +46,25 @@ class ObjectPermissionChecker(object):
         :param obj: Django model instance for which permission should be checked
 
         """
+        if '.' in perm:
+            qualified_perm = perm
+        else:
+            qualified_perm = '%s.%s' % (obj._meta.app_label, perm)
+
         perm = perm.split('.')[-1]
         if self.user and not self.user.is_active:
             return False
         elif self.user and self.user.is_superuser:
             return True
-        return perm in self.get_perms(obj)
+        return (
+                perm in self.get_perms(obj)
+                or 
+                (
+                    self.user
+                    and
+                    self.user.has_perm(qualified_perm)
+                )
+        )
 
     def get_perms(self, obj):
         """

--- a/guardian/testapp/tests/core_test.py
+++ b/guardian/testapp/tests/core_test.py
@@ -60,11 +60,11 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
             query_count = len(connection.queries)
             res = checker.has_perm("change_group", self.group)
             if 'guardian.testapp' in settings.INSTALLED_APPS:
-                expected = 5
+                expected = 7
             else:
                 # TODO: This is strange, need to investigate; totally not sure
                 # why there are more queries if testapp is not included
-                expected = 11
+                expected = 13
             self.assertEqual(len(connection.queries), query_count + expected)
 
             # Checking again shouldn't spawn any queries

--- a/guardian/testapp/tests/core_test.py
+++ b/guardian/testapp/tests/core_test.py
@@ -16,7 +16,7 @@ from guardian.core import ObjectPermissionChecker
 from guardian.compat import get_user_model, create_permissions
 from guardian.exceptions import NotUserNorGroup
 from guardian.models import UserObjectPermission, GroupObjectPermission
-from guardian.shortcuts import assign_perm
+from guardian.shortcuts import assign_perm, remove_perm
 
 User = get_user_model()
 
@@ -174,3 +174,12 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
                 GroupObjectPermission.objects.assign_perm(perm, self.group, obj)
             self.assertEqual(sorted(perms), sorted(check.get_perms(obj)))
 
+    def test_global_perm_carry_over(self):
+        from guardian.conf import settings
+        settings.GLOBAL_PERMISSIONS_CARRY_OVER = True
+
+        assign_perm('auth.change_group', self.user)
+        self.assertTrue(self.user.has_perm('change_group', self.group))
+        settings.GLOBAL_PERMISSIONS_CARRY_OVER = False
+
+        remove_perm('auth.change_group', self.user)

--- a/guardian/testapp/tests/core_test.py
+++ b/guardian/testapp/tests/core_test.py
@@ -180,6 +180,12 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
 
         assign_perm('auth.change_group', self.user)
         self.assertTrue(self.user.has_perm('change_group', self.group))
-        settings.GLOBAL_PERMISSIONS_CARRY_OVER = False
-
         remove_perm('auth.change_group', self.user)
+
+        assign_perm('auth.delete_group', self.group)
+        checker = ObjectPermissionChecker(self.group)
+        self.assertTrue(checker.has_perm('delete_group', self.group))
+        remove_perm('auth.delete_group', self.group)
+
+        settings.GLOBAL_PERMISSIONS_CARRY_OVER = False
+ 

--- a/guardian/testapp/tests/core_test.py
+++ b/guardian/testapp/tests/core_test.py
@@ -60,11 +60,11 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
             query_count = len(connection.queries)
             res = checker.has_perm("change_group", self.group)
             if 'guardian.testapp' in settings.INSTALLED_APPS:
-                expected = 7
+                expected = 5
             else:
                 # TODO: This is strange, need to investigate; totally not sure
                 # why there are more queries if testapp is not included
-                expected = 13
+                expected = 11
             self.assertEqual(len(connection.queries), query_count + expected)
 
             # Checking again shouldn't spawn any queries

--- a/guardian/testapp/tests/decorators_test.py
+++ b/guardian/testapp/tests/decorators_test.py
@@ -285,7 +285,7 @@ class PermissionRequiredTest(TestDataMixin, TestCase):
         def dummy_view(request, username):
             return HttpResponse('dummy_view')
         response = dummy_view(request, username='joe')
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 200)
 
     def test_user_has_global_perm_access(self):
 

--- a/guardian/testapp/tests/decorators_test.py
+++ b/guardian/testapp/tests/decorators_test.py
@@ -285,7 +285,7 @@ class PermissionRequiredTest(TestDataMixin, TestCase):
         def dummy_view(request, username):
             return HttpResponse('dummy_view')
         response = dummy_view(request, username='joe')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
 
     def test_user_has_global_perm_access(self):
 

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -179,3 +179,30 @@ def get_group_obj_perms_model(obj):
     from guardian.models import GroupObjectPermissionBase
     from guardian.models import GroupObjectPermission
     return get_obj_perms_model(obj, GroupObjectPermissionBase, GroupObjectPermission)
+
+
+def group_has_perm(group, perm):
+    """
+    Returns True if ``group`` has the permission ``perm``
+    """
+    app_label, codename = perm.split('.')
+    perms = group.permissions.filter(
+        codename=codename,
+        content_type__app_label=app_label
+    )
+    
+    return perms.count() > 0
+
+
+def get_qualified_perm(perm, obj):
+    """
+    Returns the fully qualified name of the permission: ``app_label.codename``
+
+    :param perm: can be a ``codename`` or an already fully qualified name
+    """
+    if '.' in perm:
+        qualified_perm = perm
+    else:
+        qualified_perm = '%s.%s' % (obj._meta.app_label, perm)
+
+    return qualified_perm


### PR DESCRIPTION
This PR adds a new setting: `GUARDIAN_GLOBAL_PERMISSIONS_CARRY_OVER`. The default is set to `False` to maintain backwards compatibility.

If this setting is set to `True`, it makes `has_perm` return `True` if an object check is performed and a global perm exists (regardless of whether the object perm exists or not).

``` python
assign_perm('auth.change_group', user)
user.has_perm('change_group', group)
# returns True even without assign_perm('change_group', user, group)
```

In my opinion, this behavior should be controlled by a project setting and not a `has_perm` parameter, since the expectation for this kind of behavior is usually defined on the level of the project and should be immutable. 
