### PR TITLE
Fixed bug with app_label==None

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -413,7 +413,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
     # a superuser has by default assigned global perms for any
     if accept_global_perms and with_superuser:
         for code in codenames:
-            if user.has_perm(app_label + '.' + code):
+            if app_label is not None and user.has_perm(app_label + '.' + code):
                 global_perms.add(code)
         for code in global_perms:
             codenames.remove(code)


### PR DESCRIPTION
I'm not sure why this is a problem, but I encountered this problem in some unit-tests for my app.
While I was reading your unit-tests for guardian.shortcuts.get_objects_for_user I realized that maybe this situation (app_label == None) should never occur.
If this is the case, maybe you need to raise an exception before, but I'm not sure of the right logic here.
