### PR TITLE
Add support for "direct_perms_only" option

### DIFF
--- a/guardian/testapp/tests/shortcuts_test.py
+++ b/guardian/testapp/tests/shortcuts_test.py
@@ -302,6 +302,7 @@ class GetUsersWithPermsTest(TestCase):
         self.user2.groups.add(self.group2)
         assign_perm("change_contenttype", self.group1, self.obj1)
         assign_perm("change_contenttype", self.user2, self.obj1)
+        assign_perm("change_contenttype", self.group2, self.obj1)
         result = get_users_with_perms(self.obj1, with_group_users=False,
             attach_perms=True)
         expected = {self.user2: ["change_contenttype"]}

--- a/guardian/testapp/tests/shortcuts_test.py
+++ b/guardian/testapp/tests/shortcuts_test.py
@@ -302,10 +302,49 @@ class GetUsersWithPermsTest(TestCase):
         self.user2.groups.add(self.group2)
         assign_perm("change_contenttype", self.group1, self.obj1)
         assign_perm("change_contenttype", self.user2, self.obj1)
-        assign_perm("change_contenttype", self.group2, self.obj1)
         result = get_users_with_perms(self.obj1, with_group_users=False,
             attach_perms=True)
         expected = {self.user2: ["change_contenttype"]}
+        self.assertEqual(result, expected)
+
+    def test_direct_perms_only(self):
+        admin = User.objects.create(username='admin', is_superuser=True)
+        self.user1.groups.add(self.group1)
+        self.user2.groups.add(self.group1)
+        assign_perm("change_contenttype", self.user1, self.obj1)
+        assign_perm("delete_contenttype", admin, self.obj1)
+        assign_perm("delete_contenttype", self.group1, self.obj1)
+        # With direct_perms_only=False (default)
+        expected = set([self.user1, self.user2, admin])
+        result = get_users_with_perms(self.obj1)
+        self.assertEqual(set(result), expected)
+        # With direct_perms_only=True
+        result = get_users_with_perms(self.obj1, direct_perms_only=True)
+        expected = set([self.user1, admin])
+        self.assertEqual(set(result), expected)
+
+    def test_direct_perms_only_perms_attached(self):
+        admin = User.objects.create(username='admin', is_superuser=True)
+        self.user1.groups.add(self.group1)
+        self.user2.groups.add(self.group1)
+        assign_perm("change_contenttype", self.user1, self.obj1)
+        assign_perm("delete_contenttype", admin, self.obj1)
+        assign_perm("delete_contenttype", self.group1, self.obj1)
+        # With direct_perms_only=False (default)
+        expected = {
+            self.user1: ["change_contenttype", "delete_contenttype"],
+            admin: ["add_contenttype", "change_contenttype", "delete_contenttype"],
+            self.user2: ["delete_contenttype"]
+        }
+        result = get_users_with_perms(self.obj1, attach_perms=True)
+        self.assertEqual(result.keys(), expected.keys())
+        for key, perms in result.items():
+            self.assertEqual(set(perms), set(expected[key]))
+        # With direct_perms_only=True
+        result = get_users_with_perms(self.obj1, attach_perms=True,
+            direct_perms_only=True)
+        expected = {self.user1: ["change_contenttype"],
+                    admin: ["delete_contenttype"]}
         self.assertEqual(result, expected)
 
     def test_without_group_users_no_result(self):


### PR DESCRIPTION
Add support for "direct_perms_only" option

This option identifies the permissions which are *directly* assigned
to a user for an object. It disregards permissions that the user may
have acquired via group memberships or superuser status.

The new option is disabled by default for backwards compatibility.

Two new unit tests are added to demonstrate behavior with and without
the option.

The purpose of the option is to allow initialization of permission
forms used to grant specific permissions to specific users,
independently of their superuser or group memberships. In other words,
I need to be able to tell if an individual user has been specifically
granted a permission so I can show this on the form, regardless of
whether the user *also* has this permission via group membership or
superuser status.

This feature responds to a need expressed in issues #327 and #46.