### PR TITLE
shortcuts: avoid using app_label when it might be None

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -413,7 +413,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
     # a superuser has by default assigned global perms for any
     if accept_global_perms and with_superuser:
         for code in codenames:
-            if user.has_perm(app_label + '.' + code):
+            if user.has_perm(ctype.app_label + '.' + code):
                 global_perms.add(code)
         for code in global_perms:
             codenames.remove(code)

--- a/guardian/testapp/tests/shortcuts_test.py
+++ b/guardian/testapp/tests/shortcuts_test.py
@@ -774,6 +774,13 @@ class GetObjectsForUser(TestCase):
          self.assertRaises(MixedContentTypeError, get_objects_for_user,
             self.user, ['auth.change_permission', 'auth.change_group'])
 
+    def test_short_codenames_with_klass(self):
+        assign_perm('contenttypes.change_contenttype', self.user, self.ctype)
+
+        objects = get_objects_for_user(self.user,
+            ['change_contenttype'], ContentType)
+        self.assertEqual([obj.name for obj in objects], [self.ctype.name])
+
 
 class GetObjectsForGroup(TestCase):
     """


### PR DESCRIPTION
app_label is not always going to be set, whereas ctype should always be available

see also 
#322  
#326 