### PR TITLE
Support keyOrder in SortedDict

### DIFF
--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -10,9 +10,11 @@ from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response, get_object_or_404, redirect
 from django.template import RequestContext
-from django.utils.datastructures import SortedDict
+try:
+    from collections import OrderedDict as SortedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict
 from django.utils.translation import ugettext, ugettext_lazy as _
-
 from guardian.compat import get_user_model, get_model_name
 from guardian.forms import UserObjectPermissionsForm
 from guardian.forms import GroupObjectPermissionsForm

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -10,12 +10,8 @@ from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response, get_object_or_404, redirect
 from django.template import RequestContext
-try:
-    from collections import OrderedDict as SortedDict
-except ImportError:
-    from django.utils.datastructures import SortedDict
 from django.utils.translation import ugettext, ugettext_lazy as _
-from guardian.compat import get_user_model, get_model_name
+from guardian.compat import get_user_model, get_model_name, sorted_dict
 from guardian.forms import UserObjectPermissionsForm
 from guardian.forms import GroupObjectPermissionsForm
 from guardian.shortcuts import get_perms
@@ -151,15 +147,12 @@ class GuardedModelAdminMixin(object):
         forms presented within the page.
         """
         obj = get_object_or_404(self.queryset(request), pk=object_pk)
-        users_perms = SortedDict(
-            get_users_with_perms(obj, attach_perms=True,
-                with_group_users=False))
-
-        users_perms.keyOrder.sort(key=lambda user:
-                                  getattr(user, get_user_model().USERNAME_FIELD))
-        groups_perms = SortedDict(
-            get_groups_with_perms(obj, attach_perms=True))
-        groups_perms.keyOrder.sort(key=lambda group: group.name)
+        users_perms = sorted_dict(
+            items=get_users_with_perms(obj, attach_perms=True, with_group_users=False),
+            key=lambda user: getattr(user, get_user_model().USERNAME_FIELD))
+        groups_perms = sorted_dict(
+            items=get_groups_with_perms(obj, attach_perms=True),
+            key=lambda group: group.name)
 
         if request.method == 'POST' and 'submit_manage_user' in request.POST:
             user_form = UserManage(request.POST)

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -33,6 +33,7 @@ __all__ = [
     'handler500',
     'mock',
     'unittest',
+    'sorted_dict'
 ]
 
 try:
@@ -145,3 +146,17 @@ def get_model_name(model):
     if django.VERSION < (1, 7):
         return model._meta.module_name
     return model._meta.model_name
+
+try:
+    from collections import OrderedDict
+
+    def sorted_dict(items, key=lambda x: x):
+        return OrderedDict(sorted(items.items(), key=lambda k, v: key(v)))
+
+except ImportError:
+    from django.utils.datastructures import SortedDict
+
+    def sorted_dict(items, key=lambda x: x):
+        data = SortedDict(items)
+        data.keyOrder.sort(key=key)
+        return data


### PR DESCRIPTION
Hello,

I am sorry @lukaszb for incorrect commit. Tests fall, due lack of support undocumented Django API. I fixed it.

Greetings,

Cześć Łukaszu,

Przepraszam za nieprawidłowy pull requests #345. Widzę, że on psuje testy z powodu wykorzystywania nieudokumentowanego API Django w jednej funkcji. Podszedłem do tego zagadnienia zbyt schematycznie

Naprawiłem to. Teraz testy wszystkie przechodzą. Nie wiem dlaczego wcześniej dla pull requestu nie dostałem powiadomienia z Travis-a.

Zaznaczam jednak, że z powodu porzucenia wsparcia dla sygnału ```post_syncdb``` nie ma kompatybilności z Django 1.9.

Pozdrawiam,