### PR TITLE
add compat OrderedDict

### DIFF
--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -148,15 +148,15 @@ class GuardedModelAdminMixin(object):
         forms presented within the page.
         """
         obj = get_object_or_404(self.queryset(request), pk=object_pk)
-        users_perms = OrderedDict(
-            get_users_with_perms(obj, attach_perms=True,
-                with_group_users=False))
 
-        users_perms.keyOrder.sort(key=lambda user:
-                                  getattr(user, get_user_model().USERNAME_FIELD))
-        groups_perms = OrderedDict(
-            get_groups_with_perms(obj, attach_perms=True))
-        groups_perms.keyOrder.sort(key=lambda group: group.name)
+        users_perms = OrderedDict(sorted(
+            get_users_with_perms(
+                obj, attach_perms=True, with_group_users=False),
+            key=lambda group: group.name))
+
+        groups_perms = OrderedDict(sorted(
+            get_groups_with_perms(obj, attach_perms=True),
+            key=lambda group: group.name))
 
         if request.method == 'POST' and 'submit_manage_user' in request.POST:
             user_form = UserManage(request.POST)

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -10,10 +10,9 @@ from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response, get_object_or_404, redirect
 from django.template import RequestContext
-from django.utils.datastructures import SortedDict
 from django.utils.translation import ugettext, ugettext_lazy as _
 
-from guardian.compat import get_user_model, get_model_name
+from guardian.compat import OrderedDict, get_user_model, get_model_name
 from guardian.forms import UserObjectPermissionsForm
 from guardian.forms import GroupObjectPermissionsForm
 from guardian.shortcuts import get_perms
@@ -149,13 +148,13 @@ class GuardedModelAdminMixin(object):
         forms presented within the page.
         """
         obj = get_object_or_404(self.queryset(request), pk=object_pk)
-        users_perms = SortedDict(
+        users_perms = OrderedDict(
             get_users_with_perms(obj, attach_perms=True,
                 with_group_users=False))
 
         users_perms.keyOrder.sort(key=lambda user:
                                   getattr(user, get_user_model().USERNAME_FIELD))
-        groups_perms = SortedDict(
+        groups_perms = OrderedDict(
             get_groups_with_perms(obj, attach_perms=True))
         groups_perms.keyOrder.sort(key=lambda group: group.name)
 

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -18,6 +18,11 @@ try:
 except ImportError:
     from django.conf.urls.defaults import url, patterns, include, handler404, handler500 # pyflakes:ignore
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict as OrderedDict
+
 __all__ = [
     'User',
     'Group',


### PR DESCRIPTION
 `django.utils.datastructures.SortedDict` is removed in Django1.9.
https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9

