### PR TITLE
Django 1.9 compatability

### DIFF
--- a/guardian/templatetags/guardian_tags.py
+++ b/guardian/templatetags/guardian_tags.py
@@ -8,14 +8,6 @@
 from __future__ import unicode_literals
 from django import template
 from django.contrib.auth.models import Group, AnonymousUser
-try:
-    # Django < 1.8
-    from django.template import get_library
-    from django.template import InvalidTemplateLibrary
-except ImportError:
-    # Django >= 1.8
-    from django.template.base import get_library
-    from django.template.base import InvalidTemplateLibrary
 from django.template.defaulttags import LoadNode
 
 from guardian.compat import get_user_model
@@ -23,41 +15,6 @@ from guardian.exceptions import NotUserNorGroup
 from guardian.core import ObjectPermissionChecker
 
 register = template.Library()
-
-
-@register.tag
-def friendly_load(parser, token):
-    '''
-    Tries to load a custom template tag set. Non existing tag libraries
-    are ignored.
-
-    This means that, if used in conjuction with ``if_has_tag``, you can try to
-    load the comments template tag library to enable comments even if the
-    comments framework is not installed.
-
-    For example::
-
-        {% load friendly_loader %}
-        {% friendly_load comments webdesign %}
-
-        {% if_has_tag render_comment_list %}
-            {% render_comment_list for obj %}
-        {% else %}
-            {% if_has_tag lorem %}
-                {% lorem %}
-            {% endif_has_tag %}
-        {% endif_has_tag %}
-    '''
-    bits = token.contents.split()
-    for taglib in bits[1:]:
-        try:
-            lib = get_library(taglib)
-            parser.add_library(lib)
-        except InvalidTemplateLibrary:
-            pass
-    return LoadNode()
-
-
 
 
 class ObjectPermissionsNode(template.Node):


### PR DESCRIPTION
I wasn't able to find out where get_template was removed, but this commit cleans up a few places where it was removed:
https://github.com/django/django/commit/24dffaf0cbe416167f99afd1d47f20732929f758

Either way this helper seems like it could live in it's own file, it does not seem like a mainstream helper.