### PR TITLE
Added tests over different backend in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,8 @@ after_success:
   - coverage report --omit "guardian/compat.py,guardian/testapp/testsettings.py" -m guardian/*.py
   - coveralls
 
-# Uncomment before pull to django-guardian/django-guardian
-# notifications:
-#   irc: "irc.freenode.net#django-guardian"
+notifications:
+  irc: "irc.freenode.net#django-guardian"
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 install:
   - travis_retry pip install -q mock==1.0.1 Django==$DJANGO_VERSION coverage coveralls
 # Install database drivers
-  - bash -c "if [[ $DATABASE_URL = postgres* ]]; then pip install psycopg2==2.4.1; fi; "
+  - bash -c "if [[ $DATABASE_URL = postgres* ]]; then pip install psycopg2==2.6.1; fi; "
   - bash -c "if [[ $DATABASE_URL = mysql* ]]; then pip install mysqlclient==1.3.7; fi; "
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,21 @@ python:
  - 3.5
 
 env:
- - DJANGO_VERSION=1.7.10
- - DJANGO_VERSION=1.8.7
- - DJANGO_VERSION=1.9.0
+ - DJANGO_VERSION=1.7.10 DATABASE_URL=postgres://postgres@/django_guardian
+ - DJANGO_VERSION=1.8.7 DATABASE_URL=postgres://postgres@/django_guardian
+ - DJANGO_VERSION=1.9.0 DATABASE_URL=postgres://postgres@/django_guardian
+ - DJANGO_VERSION=1.7.10 DATABASE_URL=mysql://root:@localhost/django_guardian
+ - DJANGO_VERSION=1.8.7 DATABASE_URL=mysql://root:@localhost/django_guardian
+ - DJANGO_VERSION=1.9.0 DATABASE_URL=mysql://root:@localhost/django_guardian
+ - DJANGO_VERSION=1.7.10 DATABASE_URL=sqlite://
+ - DJANGO_VERSION=1.8.7 DATABASE_URL=sqlite://
+ - DJANGO_VERSION=1.9.0 DATABASE_URL=sqlite://
 
 install:
   - travis_retry pip install -q mock==1.0.1 Django==$DJANGO_VERSION coverage coveralls
+# Install database drivers
+  - bash -c "if [[ $DATABASE_URL = postgres* ]]; then pip install psycopg2==2.4.1; fi; "
+  - bash -c "if [[ $DATABASE_URL = mysql* ]]; then pip install mysqlclient==1.3.7; fi; "
 
 script:
   - coverage run --source=guardian setup.py test
@@ -21,13 +30,31 @@ after_success:
   - coverage report --omit "guardian/compat.py,guardian/testapp/testsettings.py" -m guardian/*.py
   - coveralls
 
-notifications:
-  irc: "irc.freenode.net#django-guardian"
+# Uncomment before pull to django-guardian/django-guardian
+# notifications:
+#   irc: "irc.freenode.net#django-guardian"
 
 
 matrix:
     exclude:
+        # Drop python 3.3 and django 1.9
         - python: 3.3
-          env: DJANGO_VERSION=1.9.0
+          env: DJANGO_VERSION=1.9.0 DATABASE_URL=postgres://postgres@/django_guardian
+        - python: 3.3
+          env: DJANGO_VERSION=1.9.0 DATABASE_URL=mysql://root:@localhost/django_guardian
+        - python: 3.3
+          env: DJANGO_VERSION=1.9.0 DATABASE_URL=sqlite://
+        # Drop python 3.5 and django 1.7
         - python: 3.5
-          env: DJANGO_VERSION=1.7.10
+          env: DJANGO_VERSION=1.7.10 DATABASE_URL=postgres://postgres@/django_guardian
+        - python: 3.5
+          env: DJANGO_VERSION=1.7.10 DATABASE_URL=mysql://root:@localhost/django_guardian
+        - python: 3.5
+          env: DJANGO_VERSION=1.7.10 DATABASE_URL=sqlite://
+        # Drop python 3.3 with postgres due lack of driver
+        - python: 3.3
+          env: DJANGO_VERSION=1.7.10 DATABASE_URL=postgres://postgres@/django_guardian
+        - python: 3.3
+          env: DJANGO_VERSION=1.8.7 DATABASE_URL=postgres://postgres@/django_guardian
+        - python: 3.3
+          env: DJANGO_VERSION=1.9.0 DATABASE_URL=postgres://postgres@/django_guardian

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -1,7 +1,15 @@
 import os
 import sys
+from django.conf import global_settings
+import environ
+
+env = environ.Env()
 
 abspath = lambda *p: os.path.abspath(os.path.join(*p))
+
+DATABASES = DATABASES = {
+    'default': env.db(default="sqlite:///")
+}
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
@@ -11,16 +19,7 @@ PROJECT_ROOT = abspath(os.path.dirname(__file__))
 GUARDIAN_MODULE_PATH = abspath(PROJECT_ROOT, '..')
 sys.path.insert(0, GUARDIAN_MODULE_PATH)
 
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': abspath(PROJECT_ROOT, '.hidden.db'),
-    },
-    'TEST': {
-        'NAME': ':memory:',
-    }
-}
+DATABASES = {'default': env.db(default="sqlite:///")}
 
 INSTALLED_APPS = (
     'django.contrib.auth',
@@ -41,12 +40,6 @@ if 'GRAPPELLI' in os.environ:
         INSTALLED_APPS = ('grappelli',) + INSTALLED_APPS
     except ImportError:
         print("django-grappelli not installed")
-
-try:
-    import rosetta
-    INSTALLED_APPS += ('rosetta',)
-except ImportError:
-    pass
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
@@ -105,3 +98,8 @@ PASSWORD_HASHERS = (
 )
 
 AUTH_USER_MODEL = 'core.CustomUser'
+
+try:
+    from conf.localsettings import *
+except ImportError:
+    pass

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -7,9 +7,6 @@ env = environ.Env()
 
 abspath = lambda *p: os.path.abspath(os.path.join(*p))
 
-DATABASES = DATABASES = {
-    'default': env.db(default="sqlite:///")
-}
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
@@ -40,6 +37,12 @@ if 'GRAPPELLI' in os.environ:
         INSTALLED_APPS = ('grappelli',) + INSTALLED_APPS
     except ImportError:
         print("django-grappelli not installed")
+
+try:
+    import rosetta
+    INSTALLED_APPS += ('rosetta',)
+except ImportError:
+    pass
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
@@ -98,8 +101,3 @@ PASSWORD_HASHERS = (
 )
 
 AUTH_USER_MODEL = 'core.CustomUser'
-
-try:
-    from conf.localsettings import *
-except ImportError:
-    pass

--- a/guardian/testapp/testsettings.py
+++ b/guardian/testapp/testsettings.py
@@ -1,6 +1,9 @@
 import os
 import random
 import string
+import environ
+
+env = environ.Env()
 
 DEBUG = False
 
@@ -35,14 +38,6 @@ MIDDLEWARE_CLASSES = (
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': ':memory:',
-        'TEST_NAME': ':memory:',
-    },
-}
-
 ROOT_URLCONF = 'guardian.testapp.tests.urls'
 SITE_ID = 1
 
@@ -54,15 +49,4 @@ SECRET_KEY = ''.join([random.choice(string.ascii_letters) for x in range(40)])
 
 # Database specific
 
-if os.environ.get('GUARDIAN_TEST_DB_BACKEND') == 'mysql':
-    DATABASES['default']['ENGINE'] = 'django.db.backends.mysql'
-    DATABASES['default']['NAME'] = 'guardian_test'
-    DATABASES['default']['TEST_NAME'] = 'guardian_test'
-    DATABASES['default']['USER'] = os.environ.get('USER', 'root')
-
-if os.environ.get('GUARDIAN_TEST_DB_BACKEND') == 'postgresql':
-    DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'
-    DATABASES['default']['NAME'] = 'guardian'
-    DATABASES['default']['TEST_NAME'] = 'guardian_test'
-    DATABASES['default']['USER'] = os.environ.get('USER', 'postgres')
-
+DATABASES = {'default': env.db(default="sqlite:///")}

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except IOError as err:
         "``long_description`` (%s)\n" % readme_file)
     sys.exit(1)
 
-tests_require = ['mock']
+tests_require = ['mock', 'django-environ']
 
 extra_kwargs = {}
 if sys.version_info >= (3,):

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ envlist =
     py35-django19,
 
 [testenv]
+passenv = DATABASE_URL
 basepython =
     py26: python2.6
     py27: python2.7


### PR DESCRIPTION
Hello,

I added tests in Travis over different database backend (MySQL, Postgres, SQLite). The issue #366 shows this will be useful.

Not all pass tests due django-guardian bugs, but this is out of pull requests. Pass for each python, backend, django version one build, so I believe I change everything what required.

Greetings,

------
Szanowni Państwo,

Dodałem sprawdzanie w Travisie dla różnych back-endów bazy danych  (MySQL, Postgres, SQLite). Issue #366 pokazał, że to będzie użyteczne, bo są istotne różnice pomiedzy silnikami baz danych.

Nie wszystkie testy przechodzą, ale jest to poza tą propozycją zmian. Nie mogę poświęcić czasu, aby wszystkie testy naprawić. Co najmniej jeden test przechodzi dla każdej wersji Pythona, Django, back-endu, więc wierzę, że wszystko zmieniłem. Natomiast niepowodzenia w testach są spowodowane błędami w django-guardian, takimi jak #366. 

Pozdrawiam, 