### PR TITLE
Add Django master to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,14 @@ install:
   - bash -c "if [[ $DATABASE_URL = mysql* ]]; then pip install mysqlclient==1.3.7; fi; "
 
 script:
-  - bash -c 'A=$PWD; pushd "/"; coverage run --source=guardian "$A/setup.py"; test; popd "/"';
+  - coverage run --source=guardian setup.py test
 
 after_success:
   - coverage report --omit "guardian/compat.py,guardian/testapp/testsettings.py" -m guardian/*.py
   - coveralls
 
-# notifications:
-#   irc: "irc.freenode.net#django-guardian"
+notifications:
+  irc: "irc.freenode.net#django-guardian"
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,22 @@ env:
  - DJANGO_VERSION=1.7.10 DATABASE_URL=postgres://postgres@/django_guardian
  - DJANGO_VERSION=1.8.7 DATABASE_URL=postgres://postgres@/django_guardian
  - DJANGO_VERSION=1.9.1 DATABASE_URL=postgres://postgres@/django_guardian
+ - DJANGO_VERSION=master DATABASE_URL=postgres://postgres@/django_guardian
+
  - DJANGO_VERSION=1.7.10 DATABASE_URL=mysql://root:@localhost/django_guardian
  - DJANGO_VERSION=1.8.7 DATABASE_URL=mysql://root:@localhost/django_guardian
  - DJANGO_VERSION=1.9.1 DATABASE_URL=mysql://root:@localhost/django_guardian
+ - DJANGO_VERSION=master DATABASE_URL=mysql://root:@localhost/django_guardian
+
  - DJANGO_VERSION=1.7.10 DATABASE_URL=sqlite://
  - DJANGO_VERSION=1.8.7 DATABASE_URL=sqlite://
  - DJANGO_VERSION=1.9.1 DATABASE_URL=sqlite://
+ - DJANGO_VERSION=master DATABASE_URL=sqlite://
 
 install:
-  - travis_retry pip install -q mock==1.0.1 Django==$DJANGO_VERSION coverage coveralls
+  - travis_retry pip install -q mock==1.0.1 coverage coveralls
+# Install django master or version
+  - bash -c "if [[ "$DJANGO_VERSION" == 'master' ]]; then pip install 'https://github.com/django/django/archive/master.tar.gz'; else pip install Django==$DJANGO_VERSION; fi; "
 # Install database drivers
   - bash -c "if [[ $DATABASE_URL = postgres* ]]; then pip install psycopg2==2.6.1; fi; "
   - bash -c "if [[ $DATABASE_URL = mysql* ]]; then pip install mysqlclient==1.3.7; fi; "
@@ -57,3 +64,7 @@ matrix:
           env: DJANGO_VERSION=1.8.7 DATABASE_URL=postgres://postgres@/django_guardian
         - python: 3.3
           env: DJANGO_VERSION=1.9.1 DATABASE_URL=postgres://postgres@/django_guardian
+    allow_failures:
+        - env: DJANGO_VERSION=master DATABASE_URL=postgres://postgres@/django_guardian
+        - env: DJANGO_VERSION=master DATABASE_URL=mysql://root:@localhost/django_guardian
+        - env: DJANGO_VERSION=master DATABASE_URL=sqlite://

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,30 +42,30 @@ notifications:
 
 
 matrix:
-    fast_finish: true
-    exclude:
-        # Drop python 3.3 and django 1.9
-        - python: 3.3
-          env: DJANGO_VERSION=1.9.1 DATABASE_URL=postgres://postgres@/django_guardian
-        - python: 3.3
-          env: DJANGO_VERSION=1.9.1 DATABASE_URL=mysql://root:@localhost/django_guardian
-        - python: 3.3
-          env: DJANGO_VERSION=1.9.1 DATABASE_URL=sqlite://
-        # Drop python 3.5 and django 1.7
-        - python: 3.5
-          env: DJANGO_VERSION=1.7.10 DATABASE_URL=postgres://postgres@/django_guardian
-        - python: 3.5
-          env: DJANGO_VERSION=1.7.10 DATABASE_URL=mysql://root:@localhost/django_guardian
-        - python: 3.5
-          env: DJANGO_VERSION=1.7.10 DATABASE_URL=sqlite://
-        # Drop python 3.3 with postgres due lack of driver
-        - python: 3.3
-          env: DJANGO_VERSION=1.7.10 DATABASE_URL=postgres://postgres@/django_guardian
-        - python: 3.3
-          env: DJANGO_VERSION=1.8.7 DATABASE_URL=postgres://postgres@/django_guardian
-        - python: 3.3
-          env: DJANGO_VERSION=1.9.1 DATABASE_URL=postgres://postgres@/django_guardian
-    allow_failures:
-        - env: DJANGO_VERSION=master DATABASE_URL=postgres://postgres@/django_guardian
-        - env: DJANGO_VERSION=master DATABASE_URL=mysql://root:@localhost/django_guardian
-        - env: DJANGO_VERSION=master DATABASE_URL=sqlite://
+  fast_finish: true
+  exclude:
+      # Drop python 3.3 and django 1.9
+      - python: 3.3
+        env: DJANGO_VERSION=1.9.1 DATABASE_URL=postgres://postgres@/django_guardian
+      - python: 3.3
+        env: DJANGO_VERSION=1.9.1 DATABASE_URL=mysql://root:@localhost/django_guardian
+      - python: 3.3
+        env: DJANGO_VERSION=1.9.1 DATABASE_URL=sqlite://
+      # Drop python 3.5 and django 1.7
+      - python: 3.5
+        env: DJANGO_VERSION=1.7.10 DATABASE_URL=postgres://postgres@/django_guardian
+      - python: 3.5
+        env: DJANGO_VERSION=1.7.10 DATABASE_URL=mysql://root:@localhost/django_guardian
+      - python: 3.5
+        env: DJANGO_VERSION=1.7.10 DATABASE_URL=sqlite://
+      # Drop python 3.3 with postgres due lack of driver
+      - python: 3.3
+        env: DJANGO_VERSION=1.7.10 DATABASE_URL=postgres://postgres@/django_guardian
+      - python: 3.3
+        env: DJANGO_VERSION=1.8.7 DATABASE_URL=postgres://postgres@/django_guardian
+      - python: 3.3
+        env: DJANGO_VERSION=1.9.1 DATABASE_URL=postgres://postgres@/django_guardian
+  allow_failures:
+      - env: DJANGO_VERSION=master DATABASE_URL=postgres://postgres@/django_guardian
+      - env: DJANGO_VERSION=master DATABASE_URL=mysql://root:@localhost/django_guardian
+      - env: DJANGO_VERSION=master DATABASE_URL=sqlite://

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ notifications:
 
 
 matrix:
+    fast_finish: true
     exclude:
         # Drop python 3.3 and django 1.9
         - python: 3.3

--- a/tests.py
+++ b/tests.py
@@ -8,6 +8,22 @@ instructions how to interpret ``test`` command when we run::
 """
 import os
 import sys
+import contextlib
+import tempfile
+import shutil
+
+
+@contextlib.contextmanager
+def tempdir():
+    dirpath = tempfile.mkdtemp()
+    prevdir = os.getcwd()
+
+    try:
+        os.chdir(dirpath)
+        yield dirpath
+    finally:
+        os.chdir(prevdir)
+        shutil.rmtree(dirpath)
 
 
 def main():
@@ -18,7 +34,8 @@ def main():
     from django.core.management import call_command
 
     django.setup()
-    call_command('test')
+    with tempdir():
+        call_command('test')
 
     sys.exit(0)
 


### PR DESCRIPTION
Hello,

I suggest add django master to TravisCI to take awareness about future django version compatibility.  We achieve full django 1.9 compatibility yet, but not django master.

I suggest use "allow_failures", so django-master was mark in travis resultset, but not affect on general build status. The "fast_finish" mean the general build status return (fg. in github status) without waiting for "allow_failures" builds.

Greetings,
