### PR TITLE
Fix deprecated code for django 1.10 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,13 @@ matrix:
         env: DJANGO_VERSION=1.9.1 DATABASE_URL=mysql://root:@localhost/django_guardian
       - python: 3.3
         env: DJANGO_VERSION=1.9.1 DATABASE_URL=sqlite://
+      # Drop python 3.3 and django master
+      - python: 3.3
+        env: DJANGO_VERSION=master DATABASE_URL=postgres://postgres@/django_guardian
+      - python: 3.3
+        env: DJANGO_VERSION=master DATABASE_URL=mysql://root:@localhost/django_guardian
+      - python: 3.3
+        env: DJANGO_VERSION=master DATABASE_URL=sqlite://
       # Drop python 3.5 and django 1.7
       - python: 3.5
         env: DJANGO_VERSION=1.7.10 DATABASE_URL=postgres://postgres@/django_guardian

--- a/example_project/posts/urls.py
+++ b/example_project/posts/urls.py
@@ -1,8 +1,9 @@
 from guardian.compat import url
 
+from posts import views
 
 urlpatterns = [
     'posts.views',
-    url(r'^$', view='post_list', name='posts_post_list'),
-    url(r'^(?P<slug>[-\w]+)/$', view='post_detail', name='posts_post_detail'),
+    url(r'^$', views.post_list, name='posts_post_list'),
+    url(r'^(?P<slug>[-\w]+)/$', views.post_detail, name='posts_post_detail'),
 ]

--- a/example_project/posts/urls.py
+++ b/example_project/posts/urls.py
@@ -1,8 +1,8 @@
-from guardian.compat import url, patterns
+from guardian.compat import url
 
 
-urlpatterns = patterns(
+urlpatterns = [
     'posts.views',
     url(r'^$', view='post_list', name='posts_post_list'),
     url(r'^(?P<slug>[-\w]+)/$', view='post_detail', name='posts_post_detail'),
-)
+]

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -1,4 +1,4 @@
-from guardian.compat import include, url, patterns, handler404, handler500
+from guardian.compat import include, url, handler404, handler500
 from django.conf import settings
 from django.contrib import admin
 
@@ -7,22 +7,15 @@ __all__ = ['handler404', 'handler500']
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     (r'^admin/', include(admin.site.urls)),
     url(r'^logout/$', 'django.contrib.auth.views.logout', {'next_page': '/'},
         name='logout'),
     (r'^', include('posts.urls')),
-)
+]
 
 if 'grappelli' in settings.INSTALLED_APPS:
-    urlpatterns += patterns(
-        '',
-        (r'^grappelli/', include('grappelli.urls')),
-    )
+    urlpatterns += [(r'^grappelli/', include('grappelli.urls')), ]
 
 if 'rosetta' in settings.INSTALLED_APPS:
-    urlpatterns = patterns(
-        '',
-        url(r'^rosetta/', include('rosetta.urls')),
-    ) + urlpatterns
+    urlpatterns += [(r'^rosetta/', include('rosetta.urls')), ]

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -1,6 +1,7 @@
 from guardian.compat import include, url, handler404, handler500
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.auth.views import logout
 
 __all__ = ['handler404', 'handler500']
 
@@ -9,8 +10,7 @@ admin.autodiscover()
 
 urlpatterns = [
     (r'^admin/', include(admin.site.urls)),
-    url(r'^logout/$', 'django.contrib.auth.views.logout', {'next_page': '/'},
-        name='logout'),
+    url(r'^logout/$', logout, {'next_page': '/'}, name='logout'),
     (r'^', include('posts.urls')),
 ]
 

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -10,7 +10,7 @@ import sys
 
 from importlib import import_module
 
-from django.conf.urls import url, patterns, include, handler404, handler500
+from django.conf.urls import url, include, handler404, handler500
 
 __all__ = [
     'User',

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -7,7 +7,6 @@ from django.contrib.auth.models import Permission
 from django.contrib.auth.models import AnonymousUser
 import six
 import sys
-
 from importlib import import_module
 
 from django.conf.urls import url, include, handler404, handler500
@@ -129,3 +128,15 @@ def get_model_name(model):
     # model._meta.module_name is deprecated in django version 1.7 and removed
     # in django version 1.8.  It is replaced by model._meta.model_name
     return model._meta.model_name
+
+
+def template_debug_setter(value):
+    if hasattr(settings, 'TEMPLATE_DEBUG'):
+        settings.TEMPLATE_DEBUG = value
+    settings.TEMPLATES[0]['OPTIONS']['DEBUG'] = value
+
+
+def template_debug_getter():
+    if hasattr(settings, 'TEMPLATE_DEBUG'):
+        return settings.TEMPLATE_DEBUG
+    return settings.TEMPLATES[0]['OPTIONS'].get('DEBUG', False)

--- a/guardian/management/commands/clean_orphan_obj_perms.py
+++ b/guardian/management/commands/clean_orphan_obj_perms.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from guardian.utils import clean_orphan_obj_perms
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     """
     clean_orphan_obj_perms command is a tiny wrapper around
     :func:`guardian.utils.clean_orphan_obj_perms`.
@@ -17,7 +17,7 @@ class Command(NoArgsCommand):
     """
     help = "Removes object permissions with not existing targets"
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         removed = clean_orphan_obj_perms()
         if options['verbosity'] > 0:
             print("Removed %d object permission entries with no targets" %

--- a/guardian/testapp/tests/test_tags.py
+++ b/guardian/testapp/tests/test_tags.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
-from django.conf import settings
+
 from django.contrib.auth.models import Group, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.template import Template, Context, TemplateSyntaxError
 from django.test import TestCase
 
-from guardian.compat import get_user_model
+from guardian.compat import get_user_model, template_debug_getter, template_debug_setter
 from guardian.exceptions import NotUserNorGroup
 from guardian.models import UserObjectPermission, GroupObjectPermission
 
@@ -82,10 +82,10 @@ class GetObjPermsTagTest(TestCase):
         context = {'some_obj': ContentType(), 'contenttype': self.ctype}
         # This test would raise TemplateSyntaxError instead of NotUserNorGroup
         # if TEMPLATE_DEBUG is set to True during tests
-        tmp = settings.TEMPLATE_DEBUG
-        settings.TEMPLATE_DEBUG = False
+        tmp = template_debug_getter()
+        template_debug_setter(False)
         self.assertRaises(NotUserNorGroup, render, template, context)
-        settings.TEMPLATE_DEBUG = tmp
+        template_debug_setter(tmp)
 
     def test_superuser(self):
         user = User.objects.create(username='superuser', is_superuser=True)

--- a/guardian/testapp/testsettings.py
+++ b/guardian/testapp/testsettings.py
@@ -50,3 +50,23 @@ SECRET_KEY = ''.join([random.choice(string.ascii_letters) for x in range(40)])
 # Database specific
 
 DATABASES = {'default': env.db(default="sqlite:///")}
+
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': TEMPLATE_DIRS,
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]


### PR DESCRIPTION
Hello,

I prepared some commits to add supports django 1.10 compatibility.  I know django 1.10 aren't releases yet, but I only changes around deprecation warning in django 1.9 (released).

Changes:

1. Drop django.conf.urls.patterns (django 1.10 compat) in reference to https://github.com/django/django/blob/stable/1.9.x/django/conf/urls/__init__.py#L80-L85
1. Add modern settings for templates engine in reference to https://docs.djangoproject.com/en/1.9/ref/templates/upgrading/
1. Drop django.core.management.base.NoArgsCommand in reference to https://github.com/django/django/blob/stable/1.9.x/django/core/management/base.py#L574-L578
1. Drop python 3.3 & django master in Travis (lack of support in django 1.9+)
1. Drop strings view arguments in reference to https://github.com/django/django/blob/stable/1.9.x/django/conf/urls/__init__.py#L103-L108
1. Add template_debug_{setter,getter} in reference to https://docs.djangoproject.com/en/1.9/ref/templates/upgrading/ 
> If it sets TEMPLATE_DEBUG to a value that differs from DEBUG, include that value under the 'debug' key in 'OPTIONS'.

In e1916bb I'm not sure maybe versions depend will be better?

All tests pass in django-master now, even allow failures django master.

Greetings,