### PR TITLE
Forms should also be precise with permissions

### DIFF
--- a/docs/api/guardian.shortcuts.rst
+++ b/docs/api/guardian.shortcuts.rst
@@ -28,6 +28,22 @@ get_perms
 .. autofunction:: guardian.shortcuts.get_perms
 
 
+.. _api-shortcuts-get_user_perms:
+
+get_user_perms
+--------------
+
+.. autofunction:: guardian.shortcuts.get_user_perms
+
+
+.. _api-shortcuts-get_group_perms:
+
+get_group_perms
+---------------
+
+.. autofunction:: guardian.shortcuts.get_group_perms
+
+
 .. _api-shortcuts-get_perms_for_model:
 
 get_perms_for_model

--- a/docs/userguide/check.rst
+++ b/docs/userguide/check.rst
@@ -61,6 +61,14 @@ both ``User`` and ``Group`` instances. If we need to do some more work, we
 can use lower level ``ObjectPermissionChecker`` class which is described in 
 the next section.
 
+There is also ``get_user_perms`` to get permissions assigned directly to the user
+(and not inherited from its superuser status or group membership.
+Similarly, ``get_group_perms`` returns only permissions which are inferred
+through user's group membership.
+``get_user_perms`` and ``get_group_perms`` are useful when you care what permissions
+user has assigned, while ``has_perm`` is useful when you care about user's effective
+permissions.
+
 get_objects_for_user
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/guardian/forms.py
+++ b/guardian/forms.py
@@ -5,7 +5,8 @@ from django.utils.translation import ugettext as _
 
 from guardian.shortcuts import assign_perm
 from guardian.shortcuts import remove_perm
-from guardian.shortcuts import get_perms
+from guardian.shortcuts import get_user_perms
+from guardian.shortcuts import get_group_perms
 from guardian.shortcuts import get_perms_for_model
 
 
@@ -127,7 +128,7 @@ class UserObjectPermissionsForm(BaseObjectPermissionsForm):
         super(UserObjectPermissionsForm, self).__init__(*args, **kwargs)
 
     def get_obj_perms_field_initial(self):
-        perms = get_perms(self.user, self.obj)
+        perms = get_user_perms(self.user, self.obj)
         return perms
 
     def save_obj_perms(self):
@@ -174,7 +175,7 @@ class GroupObjectPermissionsForm(BaseObjectPermissionsForm):
         super(GroupObjectPermissionsForm, self).__init__(*args, **kwargs)
 
     def get_obj_perms_field_initial(self):
-        perms = get_perms(self.group, self.obj)
+        perms = get_group_perms(self.group, self.obj)
         return perms
 
     def save_obj_perms(self):

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -338,6 +338,11 @@ class GetUsersWithPermsTest(TestCase):
         self.assertEqual(set(get_group_perms(self.group1, self.obj1)), set(['delete_contenttype']))
         self.assertEqual(set(get_group_perms(self.group2, self.obj1)), set([]))
         self.assertEqual(set(get_group_perms(admin, self.obj1)), set([]))
+        self.assertEqual(set(get_perms(admin, self.obj1)), set(['add_contenttype', 'change_contenttype', 'delete_contenttype']))
+        self.assertEqual(set(get_perms(self.user1, self.obj1)), set(['change_contenttype', 'delete_contenttype']))
+        self.assertEqual(set(get_perms(self.user2, self.obj1)), set(['delete_contenttype']))
+        self.assertEqual(set(get_perms(self.group1, self.obj1)), set(['delete_contenttype']))
+        self.assertEqual(set(get_perms(self.group2, self.obj1)), set([]))
 
     def test_direct_perms_only_perms_attached(self):
         admin = User.objects.create(username='admin', is_superuser=True)

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -315,6 +315,43 @@ class GetUsersWithPermsTest(TestCase):
         expected = {self.user2: ["change_contenttype"]}
         self.assertEqual(result, expected)
 
+    def test_direct_perms_only(self):
+        admin = User.objects.create(username='admin', is_superuser=True)
+        self.user1.groups.add(self.group1)
+        self.user2.groups.add(self.group1)
+        assign_perm("change_contenttype", self.user1, self.obj1)
+        assign_perm("delete_contenttype", admin, self.obj1)
+        assign_perm("delete_contenttype", self.group1, self.obj1)
+        expected = set([self.user1, self.user2, admin])
+        result = get_users_with_perms(self.obj1, with_superusers=False, with_group_users=True)
+        self.assertEqual(set(result), expected)
+        result = get_users_with_perms(self.obj1, with_superusers=False, with_group_users=False)
+        expected = set([self.user1, admin])
+        self.assertEqual(set(result), expected)
+
+    def test_direct_perms_only_perms_attached(self):
+        admin = User.objects.create(username='admin', is_superuser=True)
+        self.user1.groups.add(self.group1)
+        self.user2.groups.add(self.group1)
+        assign_perm("change_contenttype", self.user1, self.obj1)
+        assign_perm("delete_contenttype", admin, self.obj1)
+        assign_perm("delete_contenttype", self.group1, self.obj1)
+        expected = {
+            self.user1: ["change_contenttype", "delete_contenttype"],
+            admin: ["add_contenttype", "change_contenttype", "delete_contenttype"],
+            self.user2: ["delete_contenttype"]
+        }
+        result = get_users_with_perms(self.obj1, attach_perms=True,
+            with_superusers=False, with_group_users=True)
+        self.assertEqual(result.keys(), expected.keys())
+        for key, perms in result.items():
+            self.assertEqual(set(perms), set(expected[key]))
+        result = get_users_with_perms(self.obj1, attach_perms=True,
+            with_superusers=False, with_group_users=False)
+        expected = {self.user1: ["change_contenttype"],
+                    admin: ["delete_contenttype"]}
+        self.assertEqual(result, expected)
+
     def test_without_group_users_no_result(self):
         self.user1.groups.add(self.group1)
         assign_perm("change_contenttype", self.group1, self.obj1)

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -13,6 +13,8 @@ from guardian.shortcuts import assign
 from guardian.shortcuts import assign_perm
 from guardian.shortcuts import remove_perm
 from guardian.shortcuts import get_perms
+from guardian.shortcuts import get_user_perms
+from guardian.shortcuts import get_group_perms
 from guardian.shortcuts import get_users_with_perms
 from guardian.shortcuts import get_groups_with_perms
 from guardian.shortcuts import get_objects_for_user
@@ -325,9 +327,17 @@ class GetUsersWithPermsTest(TestCase):
         expected = set([self.user1, self.user2, admin])
         result = get_users_with_perms(self.obj1, with_superusers=False, with_group_users=True)
         self.assertEqual(set(result), expected)
+        self.assertEqual(set(get_user_perms(self.user1, self.obj1)), set(['change_contenttype']))
+        self.assertEqual(set(get_user_perms(self.user2, self.obj1)), set([]))
+        self.assertEqual(set(get_user_perms(admin, self.obj1)), set(['delete_contenttype']))
         result = get_users_with_perms(self.obj1, with_superusers=False, with_group_users=False)
         expected = set([self.user1, admin])
         self.assertEqual(set(result), expected)
+        self.assertEqual(set(get_group_perms(self.user1, self.obj1)), set(['delete_contenttype']))
+        self.assertEqual(set(get_group_perms(self.user2, self.obj1)), set(['delete_contenttype']))
+        self.assertEqual(set(get_group_perms(self.group1, self.obj1)), set(['delete_contenttype']))
+        self.assertEqual(set(get_group_perms(self.group2, self.obj1)), set([]))
+        self.assertEqual(set(get_group_perms(admin, self.obj1)), set([]))
 
     def test_direct_perms_only_perms_attached(self):
         admin = User.objects.create(username='admin', is_superuser=True)


### PR DESCRIPTION
This is a followup to #403 and addresses the issue @brianmay discovered.