### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ work with older Django_ releases.
 Documentation
 -------------
 
-Online documentation is available at http://django-guardian.rtfd.org/.
+Online documentation is available at https://django-guardian.readthedocs.io/.
 
 Installation
 ------------

--- a/example_project/templates/base.html
+++ b/example_project/templates/base.html
@@ -27,7 +27,7 @@
                             <li class="active"><a href="{% url "posts_post_list" %}">Posts</a></li>
                             <li><a href="https://github.com/django-guardian/django-guardian" target="_repo">Repository</a></li>
                             <li><a href="https://github.com/django-guardian/django-guardian/issues" target="_issues">Issue tracker</a></li>
-                            <li><a href="https://django-guardian.readthedocs.org/en/latest/" target="_docs">Documentation</a></li>
+                            <li><a href="https://django-guardian.readthedocs.io/en/latest/" target="_docs">Documentation</a></li>
                         </ul>
                         <p class="navbar-text pull-right">
                         {% if user.is_authenticated %}


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.