### PR TITLE
Allow content type retrieval to be overridden.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -135,3 +135,21 @@ Defaults to ``"guardian.management.get_init_anonymous_user"``.
 
 
 .. seealso:: :ref:`custom-user-model-anonymous`
+
+GUARDIAN_GET_CONTENT_TYPE
+-------------------------
+
+.. versionadded:: 1.5
+
+Guardian allows applications to supply a custom function to retrieve the
+content type from objects and models. This is useful when a class or class
+hierarchy uses the ``ContentType`` framework in an non-standard way. Most
+applications will not have to change this setting.
+
+As an example, when using ``django-polymorphic`` it's useful to use a
+permission on the base model which applies to all child models. In this case,
+the custom function would return the ``ContentType`` of the base class for
+polymorphic models and the regular model ``ContentType`` for non-polymorphic
+classes.
+
+Defaults to ``"guardian.ctypes.get_default_content_type"``.

--- a/guardian/conf/settings.py
+++ b/guardian/conf/settings.py
@@ -20,6 +20,8 @@ GET_INIT_ANONYMOUS_USER = getattr(settings, 'GUARDIAN_GET_INIT_ANONYMOUS_USER',
 
 MONKEY_PATCH = getattr(settings, 'GUARDIAN_MONKEY_PATCH', True)
 
+GET_CONTENT_TYPE = getattr(settings, 'GUARDIAN_GET_CONTENT_TYPE', 'guardian.ctypes.get_default_content_type')
+
 
 def check_configuration():
     if RENDER_403 and RAISE_403:

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals
 from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
 from django.db.models.query import QuerySet
 from django.utils.encoding import force_text
 from guardian.compat import get_user_model
+from guardian.ctypes import get_content_type
 from guardian.utils import get_group_obj_perms_model, get_identity, get_user_obj_perms_model
 from itertools import chain
 
@@ -17,13 +17,13 @@ def _get_pks_model_and_ctype(objects):
     if isinstance(objects, QuerySet):
         model = objects.model
         pks = [force_text(pk) for pk in objects.values_list('pk', flat=True)]
-        ctype = ContentType.objects.get_for_model(model)
+        ctype = get_content_type(model)
     else:
         pks = []
         for idx, obj in enumerate(objects):
             if not idx:
                 model = type(obj)
-                ctype = ContentType.objects.get_for_model(model)
+                ctype = get_content_type(model)
             pks.append(force_text(obj.pk))
 
     return pks, model, ctype
@@ -76,7 +76,7 @@ class ObjectPermissionChecker(object):
 
     def get_group_filters(self, obj):
         User = get_user_model()
-        ctype = ContentType.objects.get_for_model(obj)
+        ctype = get_content_type(obj)
 
         group_model = get_group_obj_perms_model(obj)
         group_rel_name = group_model.permission.field.related_query_name()
@@ -99,7 +99,7 @@ class ObjectPermissionChecker(object):
         return group_filters
 
     def get_user_filters(self, obj):
-        ctype = ContentType.objects.get_for_model(obj)
+        ctype = get_content_type(obj)
         model = get_user_obj_perms_model(obj)
         related_name = model.permission.field.related_query_name()
 
@@ -115,7 +115,7 @@ class ObjectPermissionChecker(object):
         return user_filters
 
     def get_user_perms(self, obj):
-        ctype = ContentType.objects.get_for_model(obj)
+        ctype = get_content_type(obj)
 
         perms_qs = Permission.objects.filter(content_type=ctype)
         user_filters = self.get_user_filters(obj)
@@ -125,7 +125,7 @@ class ObjectPermissionChecker(object):
         return user_perms
 
     def get_group_perms(self, obj):
-        ctype = ContentType.objects.get_for_model(obj)
+        ctype = get_content_type(obj)
 
         perms_qs = Permission.objects.filter(content_type=ctype)
         group_filters = self.get_group_filters(obj)
@@ -143,7 +143,7 @@ class ObjectPermissionChecker(object):
         """
         if self.user and not self.user.is_active:
             return []
-        ctype = ContentType.objects.get_for_model(obj)
+        ctype = get_content_type(obj)
         key = self.get_local_cache_key(obj)
         if key not in self._obj_perms_cache:
             if self.user and self.user.is_superuser:
@@ -169,7 +169,7 @@ class ObjectPermissionChecker(object):
         """
         Returns cache key for ``_obj_perms_cache`` dict.
         """
-        ctype = ContentType.objects.get_for_model(obj)
+        ctype = get_content_type(obj)
         return (ctype.id, force_text(obj.pk))
 
     def prefetch_perms(self, objects):

--- a/guardian/ctypes.py
+++ b/guardian/ctypes.py
@@ -1,0 +1,49 @@
+from __future__ import unicode_literals
+
+from django.contrib.contenttypes.models import ContentType
+
+from guardian.conf import settings as guardian_settings
+from guardian.compat import import_string
+
+
+def get_content_type(obj):
+    get_content_type_function = import_string(
+        guardian_settings.GET_CONTENT_TYPE)
+    return get_content_type_function(obj)
+
+
+def get_default_content_type(obj):
+    return ContentType.objects.get_for_model(obj)
+
+
+#
+# Just for example. Will not be included with django-guardian.
+#
+def get_polymorphic_base_content_type(obj):
+    """
+    Special helper function to return BASE polymorphic ctype id
+    """
+    if hasattr(obj, 'polymorphic_model_marker'):
+        try:
+            superclasses = list(obj.__class__.mro())
+        except TypeError:
+            # obj is an object so mro() need to be called with the obj.
+            superclasses = list(obj.__class__.mro(obj))
+
+        polymorphic_superclasses = list()
+        for sclass in superclasses:
+            if hasattr(sclass, 'polymorphic_model_marker'):
+                polymorphic_superclasses.append(sclass)
+
+        # PolymorphicMPTT adds an additional class between polymorphic and
+        # base class
+        if hasattr(obj, 'can_have_children'):
+            root_polymorphic_class = polymorphic_superclasses[-3]
+        else:
+            root_polymorphic_class = polymorphic_superclasses[-2]
+        ctype = ContentType.objects.get_for_model(root_polymorphic_class)
+
+    else:
+        ctype = ContentType.objects.get_for_model(obj)
+
+    return ctype

--- a/guardian/ctypes.py
+++ b/guardian/ctypes.py
@@ -14,36 +14,3 @@ def get_content_type(obj):
 
 def get_default_content_type(obj):
     return ContentType.objects.get_for_model(obj)
-
-
-#
-# Just for example. Will not be included with django-guardian.
-#
-def get_polymorphic_base_content_type(obj):
-    """
-    Special helper function to return BASE polymorphic ctype id
-    """
-    if hasattr(obj, 'polymorphic_model_marker'):
-        try:
-            superclasses = list(obj.__class__.mro())
-        except TypeError:
-            # obj is an object so mro() need to be called with the obj.
-            superclasses = list(obj.__class__.mro(obj))
-
-        polymorphic_superclasses = list()
-        for sclass in superclasses:
-            if hasattr(sclass, 'polymorphic_model_marker'):
-                polymorphic_superclasses.append(sclass)
-
-        # PolymorphicMPTT adds an additional class between polymorphic and
-        # base class
-        if hasattr(obj, 'can_have_children'):
-            root_polymorphic_class = polymorphic_superclasses[-3]
-        else:
-            root_polymorphic_class = polymorphic_superclasses[-2]
-        ctype = ContentType.objects.get_for_model(root_polymorphic_class)
-
-    else:
-        ctype = ContentType.objects.get_for_model(obj)
-
-    return ctype

--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
-from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models import Q
 from guardian.core import ObjectPermissionChecker
+from guardian.ctypes import get_content_type
 from guardian.exceptions import ObjectNotPersisted
 from guardian.models import Permission
 
@@ -34,8 +34,7 @@ class BaseObjectPermissionManager(models.Manager):
         if getattr(obj, 'pk', None) is None:
             raise ObjectNotPersisted("Object %s needs to be persisted first"
                                      % obj)
-
-        ctype = ContentType.objects.get_for_model(obj)
+        ctype = get_content_type(obj)
         if not isinstance(perm, Permission):
             permission = Permission.objects.get(content_type=ctype, codename=perm)
         else:
@@ -56,7 +55,7 @@ class BaseObjectPermissionManager(models.Manager):
         ``user_or_group``.
         """
 
-        ctype = ContentType.objects.get_for_model(queryset.model)
+        ctype = get_content_type(queryset.model)
         if not isinstance(perm, Permission):
             permission = Permission.objects.get(content_type=ctype, codename=perm)
         else:
@@ -102,7 +101,7 @@ class BaseObjectPermissionManager(models.Manager):
             filters &= Q(permission=perm)
         else:
             filters &= Q(permission__codename=perm,
-                         permission__content_type=ContentType.objects.get_for_model(obj))
+                         permission__content_type=get_content_type(obj))
 
         if self.is_generic():
             filters &= Q(object_pk=obj.pk)
@@ -123,7 +122,7 @@ class BaseObjectPermissionManager(models.Manager):
         if isinstance(perm, Permission):
             filters &= Q(permission=perm)
         else:
-            ctype = ContentType.objects.get_for_model(queryset.model)
+            ctype = get_content_type(queryset.model)
             filters &= Q(permission__codename=perm,
                          permission__content_type=ctype)
 

--- a/guardian/models.py
+++ b/guardian/models.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from guardian.compat import unicode, user_model_label
+from guardian.ctypes import get_content_type
 from guardian.managers import GroupObjectPermissionManager, UserObjectPermissionManager
 
 try:
@@ -30,7 +31,7 @@ class BaseObjectPermission(models.Model):
             unicode(self.permission.codename))
 
     def save(self, *args, **kwargs):
-        content_type = ContentType.objects.get_for_model(self.content_object)
+        content_type = get_content_type(self.content_object)
         if content_type != self.permission.content_type:
             raise ValidationError("Cannot persist permission not designed for "
                                   "this class (permission's type is %r and object's type is %r)"

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -9,6 +9,7 @@ from django.db.models import Count, Q, QuerySet
 from django.shortcuts import _get_queryset
 from guardian.compat import basestring, get_user_model
 from guardian.core import ObjectPermissionChecker
+from guardian.ctypes import get_content_type
 from guardian.exceptions import MixedContentTypeError, WrongAppError
 from guardian.utils import get_anonymous_user, get_group_obj_perms_model, get_identity, get_user_obj_perms_model
 from itertools import groupby
@@ -200,7 +201,7 @@ def get_perms_for_model(cls):
         model = apps.get_model(app_label, model_name)
     else:
         model = cls
-    ctype = ContentType.objects.get_for_model(model)
+    ctype = get_content_type(model)
     return Permission.objects.filter(content_type=ctype)
 
 
@@ -240,7 +241,7 @@ def get_users_with_perms(obj, attach_perms=False, with_superusers=False,
         {<User: joe>: [u'change_flatpage']}
 
     """
-    ctype = ContentType.objects.get_for_model(obj)
+    ctype = get_content_type(obj)
     if not attach_perms:
         # It's much easier without attached perms so we do it first if that is
         # the case
@@ -312,7 +313,7 @@ def get_groups_with_perms(obj, attach_perms=False):
         {<Group: admins>: [u'change_flatpage']}
 
     """
-    ctype = ContentType.objects.get_for_model(obj)
+    ctype = get_content_type(obj)
     if not attach_perms:
         # It's much easier without attached perms so we do it first if that is
         # the case
@@ -470,7 +471,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
     # Compute queryset and ctype if still missing
     if ctype is None and klass is not None:
         queryset = _get_queryset(klass)
-        ctype = ContentType.objects.get_for_model(queryset.model)
+        ctype = get_content_type(queryset.model)
     elif ctype is not None and klass is None:
         queryset = _get_queryset(ctype.model_class())
     elif klass is None:
@@ -673,7 +674,7 @@ def get_objects_for_group(group, perms, klass=None, any_perm=False, accept_globa
     # Compute queryset and ctype if still missing
     if ctype is None and klass is not None:
         queryset = _get_queryset(klass)
-        ctype = ContentType.objects.get_for_model(queryset.model)
+        ctype = get_content_type(queryset.model)
     elif ctype is not None and klass is None:
         queryset = _get_queryset(ctype.model_class())
     elif klass is None:

--- a/guardian/testapp/tests/test_conf.py
+++ b/guardian/testapp/tests/test_conf.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 import mock
 from guardian.conf import settings as guardian_settings
+from guardian.ctypes import get_content_type
 
 
 class TestConfiguration(TestCase):
@@ -13,3 +14,12 @@ class TestConfiguration(TestCase):
             with mock.patch('guardian.conf.settings.RAISE_403', True):
                 self.assertRaises(ImproperlyConfigured,
                                   guardian_settings.check_configuration)
+
+    def test_get_content_type(self):
+        with mock.patch('guardian.conf.settings.GET_CONTENT_TYPE', 'guardian.testapp.tests.test_conf.get_test_content_type'):
+            self.assertEqual(get_content_type(None), 'x')
+
+
+def get_test_content_type(obj):
+    """ Used in TestConfiguration.test_get_content_type()."""
+    return 'x'

--- a/guardian/testapp/tests/test_custompkmodel.py
+++ b/guardian/testapp/tests/test_custompkmodel.py
@@ -8,7 +8,7 @@ from guardian.shortcuts import assign_perm, remove_perm
 
 class CustomPKModelTest(TestCase):
     """
-    Tests agains custom model with primary key other than *standard*
+    Tests against custom model with primary key other than *standard*
     ``id`` integer field.
     """
 

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -10,14 +10,14 @@ from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.models import AnonymousUser, Group
 from django.contrib.auth.views import redirect_to_login
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.db.models import Model
 from django.http import HttpResponseForbidden
 from django.shortcuts import render_to_response
-from django.template import RequestContext, TemplateDoesNotExist
+from django.template import RequestContext
 from guardian.compat import get_user_model
 from guardian.conf import settings as guardian_settings
+from guardian.ctypes import get_content_type
 from guardian.exceptions import NotUserNorGroup
 from itertools import chain
 
@@ -145,7 +145,7 @@ def clean_orphan_obj_perms():
 def get_obj_perms_model(obj, base_cls, generic_cls):
     if isinstance(obj, Model):
         obj = obj.__class__
-    ctype = ContentType.objects.get_for_model(obj)
+    ctype = get_content_type(obj)
 
     if django.VERSION >= (1, 8):
         fields = (f for f in obj._meta.get_fields()
@@ -165,7 +165,7 @@ def get_obj_perms_model(obj, base_cls, generic_cls):
                 # make sure that content_object's content_type is same as
                 # the one of given obj
                 fk = model._meta.get_field('content_object')
-                if ctype == ContentType.objects.get_for_model(fk.rel.to):
+                if ctype == get_content_type(fk.rel.to):
                     return model
     return generic_cls
 


### PR DESCRIPTION
This is an implementation of user settable content type retrieval that I mentioned in  #421. I'd like to hear your thoughts on this strategy. This is just a first version. I still need to complete a few tasks but I wanted to make sure I'm heading in the right direction before I finish this up. Let me know what you think.

Here are the outstanding tasks:
* Add tests
* Add docs
* Remove `get_polymorphic_base_content_type` method as it should be in my project or django-polymorphic. 