### PR TITLE
Bulk assign permissions for multiple objects

### DIFF
--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -31,8 +31,12 @@ class UserObjectPermissionManager(BaseObjectPermissionManager):
         if getattr(obj, 'pk', None) is None:
             raise ObjectNotPersisted("Object %s needs to be persisted first"
                                      % obj)
+
         ctype = ContentType.objects.get_for_model(obj)
-        permission = Permission.objects.get(content_type=ctype, codename=perm)
+        if not isinstance(perm, Permission):
+            permission = Permission.objects.get(content_type=ctype, codename=perm)
+        else:
+            permission = perm
 
         kwargs = {'permission': permission, 'user': user}
         if self.is_generic():
@@ -81,8 +85,13 @@ class GroupObjectPermissionManager(BaseObjectPermissionManager):
         if getattr(obj, 'pk', None) is None:
             raise ObjectNotPersisted("Object %s needs to be persisted first"
                                      % obj)
+
         ctype = ContentType.objects.get_for_model(obj)
-        permission = Permission.objects.get(content_type=ctype, codename=perm)
+        if not isinstance(perm, Permission):
+            ctype = ContentType.objects.get_for_model(obj)
+            permission = Permission.objects.get(content_type=ctype, codename=perm)
+        else:
+            permission = perm
 
         kwargs = {'permission': permission, 'group': group}
         if self.is_generic():

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -25,7 +25,7 @@ import warnings
 
 def assign_perm(perm, user_or_group, obj=None):
     """
-    Assigns permission to user/group and object pair.
+    Assigns permission to user/group and object pair(s).
 
     :param perm: proper permission for given ``obj``, as string (in format:
       ``app_label.codename`` or ``codename``). If ``obj`` is not given, must
@@ -35,8 +35,9 @@ def assign_perm(perm, user_or_group, obj=None):
       passing any other object would raise
       ``guardian.exceptions.NotUserNorGroup`` exception
 
-    :param obj: persisted Django's ``Model`` instance or ``None`` if assigning
-      global permission. Default is ``None``.
+    :param obj: persisted Django's ``Model`` instance, QuerySet of ``Model``
+      instances, or ``None`` if assigning global permission. Default is
+      ``None``.
 
     We can assign permission for ``Model`` instance for specific user:
 
@@ -56,6 +57,15 @@ def assign_perm(perm, user_or_group, obj=None):
     >>> user.groups.add(group)
     >>> assign_perm("delete_site", group, site)
     <GroupObjectPermission: example.com | joe-group | delete_site>
+    >>> user.has_perm("delete_site", site)
+    True
+
+    ... or the same for a queryset:
+
+    >>> sites = Site.objects.all()
+    >>> assign_perm("delete_site", user, sites)
+    [<GroupObjectPermission: example.org | joe | delete_site>, ...]
+    >>> site = Site.objects.get(domain='example.org')
     >>> user.has_perm("delete_site", site)
     True
 
@@ -115,7 +125,7 @@ def assign(perm, user_or_group, obj=None):
 
 def remove_perm(perm, user_or_group=None, obj=None):
     """
-    Removes permission from user/group and object pair.
+    Removes permission from user/group and object pair(s).
 
     :param perm: proper permission for given ``obj``, as string (in format:
       ``app_label.codename`` or ``codename``). If ``obj`` is not given, must
@@ -125,8 +135,9 @@ def remove_perm(perm, user_or_group=None, obj=None):
       passing any other object would raise
       ``guardian.exceptions.NotUserNorGroup`` exception
 
-    :param obj: persisted Django's ``Model`` instance or ``None`` if assigning
-      global permission. Default is ``None``.
+    :param obj: persisted Django's ``Model`` instance, QuerySet of ``Model``
+      instances, or ``None`` if assigning global permission. Default is
+      ``None``.
 
     """
     user, group = get_identity(user_or_group)

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -144,13 +144,23 @@ def remove_perm(perm, user_or_group=None, obj=None):
         elif group:
             group.permissions.remove(perm)
             return
+
     perm = perm.split('.')[-1]
-    if user:
-        model = get_user_obj_perms_model(obj)
-        model.objects.remove_perm(perm, user, obj)
-    if group:
-        model = get_group_obj_perms_model(obj)
-        model.objects.remove_perm(perm, group, obj)
+    try:
+        for instance in obj:
+            if user:
+                model = get_user_obj_perms_model(instance)
+            if group:
+                model = get_group_obj_perms_model(instance)
+
+            model.objects.remove_perm(perm, user or group, instance)
+    except TypeError:
+        if user:
+            model = get_user_obj_perms_model(obj)
+            model.objects.remove_perm(perm, user, obj)
+        if group:
+            model = get_group_obj_perms_model(obj)
+            model.objects.remove_perm(perm, group, obj)
 
 
 def get_perms(user_or_group, obj):

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -86,13 +86,25 @@ def assign_perm(perm, user_or_group, obj=None):
         if group:
             group.permissions.add(perm)
             return perm
+
     perm = perm.split('.')[-1]
-    if user:
-        model = get_user_obj_perms_model(obj)
-        return model.objects.assign_perm(perm, user, obj)
-    if group:
-        model = get_group_obj_perms_model(obj)
-        return model.objects.assign_perm(perm, group, obj)
+    try:
+        assigned_perms = []
+        for instance in obj:
+            if user:
+                model = get_user_obj_perms_model(instance)
+            if group:
+                model = get_group_obj_perms_model(instance)
+
+            assigned_perms.append(model.objects.assign_perm(perm, user or group, instance))
+        return assigned_perms
+    except TypeError:
+        if user:
+            model = get_user_obj_perms_model(obj)
+            return model.objects.assign_perm(perm, user, obj)
+        if group:
+            model = get_group_obj_perms_model(obj)
+            return model.objects.assign_perm(perm, group, obj)
 
 
 def assign(perm, user_or_group, obj=None):

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -42,6 +42,7 @@ class ObjectPermissionTestCase(TestCase):
         self.user.groups.add(self.group)
         self.ctype = ContentType.objects.create(
             model='bar', app_label='fake-for-guardian-tests')
+        self.ctype_qset = ContentType.objects.filter(model='bar', app_label='fake-for-guardian-tests')
         self.anonymous_user = User.objects.get(
             username=guardian_settings.ANONYMOUS_USER_NAME)
 

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -11,7 +11,9 @@ from guardian.compat import get_user_model
 from guardian.compat import get_user_permission_full_codename, get_model_name
 from guardian.shortcuts import assign
 from guardian.shortcuts import assign_perm
+from guardian.shortcuts import bulk_assign_perm
 from guardian.shortcuts import remove_perm
+from guardian.shortcuts import bulk_remove_perm
 from guardian.shortcuts import get_perms
 from guardian.shortcuts import get_user_perms
 from guardian.shortcuts import get_group_perms
@@ -81,15 +83,15 @@ class AssignPermTest(ObjectPermissionTestCase):
         self.assertTrue(check.has_perm("change_contenttype", self.ctype))
         self.assertTrue(check.has_perm("delete_contenttype", self.ctype))
 
-    def test_user_assign_perm_queryset(self):
-        assign_perm("change_contenttype", self.user, self.ctype_qset)
-        assign_perm("change_contenttype", self.group, self.ctype_qset)
+    def test_user_bulk_assign_perm(self):
+        bulk_assign_perm("change_contenttype", self.user, self.ctype_qset)
+        bulk_assign_perm("change_contenttype", self.group, self.ctype_qset)
         for obj in self.ctype_qset:
             self.assertTrue(self.user.has_perm("change_contenttype", obj))
 
-    def test_group_assign_perm_queryset(self):
-        assign_perm("change_contenttype", self.group, self.ctype_qset)
-        assign_perm("delete_contenttype", self.group, self.ctype_qset)
+    def test_group_bulk_assign_perm(self):
+        bulk_assign_perm("change_contenttype", self.group, self.ctype_qset)
+        bulk_assign_perm("delete_contenttype", self.group, self.ctype_qset)
 
         check = ObjectPermissionChecker(self.group)
         for obj in self.ctype_qset:
@@ -145,15 +147,15 @@ class RemovePermTest(ObjectPermissionTestCase):
         check = ObjectPermissionChecker(self.group)
         self.assertFalse(check.has_perm("change_contenttype", self.ctype))
 
-    def test_user_remove_perm_queryset(self):
-        assign_perm("change_contenttype", self.user, self.ctype_qset)
-        remove_perm("change_contenttype", self.user, self.ctype_qset)
+    def test_user_bulk_remove_perm(self):
+        bulk_assign_perm("change_contenttype", self.user, self.ctype_qset)
+        bulk_remove_perm("change_contenttype", self.user, self.ctype_qset)
         for obj in self.ctype_qset:
             self.assertFalse(self.user.has_perm("change_contenttype", obj))
 
-    def test_group_remove_perm_queryset(self):
-        assign_perm("change_contenttype", self.group, self.ctype_qset)
-        remove_perm("change_contenttype", self.group, self.ctype_qset)
+    def test_group_bulk_remove_perm(self):
+        bulk_assign_perm("change_contenttype", self.group, self.ctype_qset)
+        bulk_remove_perm("change_contenttype", self.group, self.ctype_qset)
 
         check = ObjectPermissionChecker(self.group)
         for obj in self.ctype_qset:

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -145,6 +145,20 @@ class RemovePermTest(ObjectPermissionTestCase):
         check = ObjectPermissionChecker(self.group)
         self.assertFalse(check.has_perm("change_contenttype", self.ctype))
 
+    def test_user_remove_perm_queryset(self):
+        assign_perm("change_contenttype", self.user, self.ctype_qset)
+        remove_perm("change_contenttype", self.user, self.ctype_qset)
+        for obj in self.ctype_qset:
+            self.assertFalse(self.user.has_perm("change_contenttype", obj))
+
+    def test_group_remove_perm_queryset(self):
+        assign_perm("change_contenttype", self.group, self.ctype_qset)
+        remove_perm("change_contenttype", self.group, self.ctype_qset)
+
+        check = ObjectPermissionChecker(self.group)
+        for obj in self.ctype_qset:
+            self.assertFalse(check.has_perm("change_contenttype", obj))
+
     def test_user_remove_perm_global(self):
         # assign perm first
         perm = "contenttypes.change_contenttype"

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -81,6 +81,21 @@ class AssignPermTest(ObjectPermissionTestCase):
         self.assertTrue(check.has_perm("change_contenttype", self.ctype))
         self.assertTrue(check.has_perm("delete_contenttype", self.ctype))
 
+    def test_user_assign_perm_queryset(self):
+        assign_perm("change_contenttype", self.user, self.ctype_qset)
+        assign_perm("change_contenttype", self.group, self.ctype_qset)
+        for obj in self.ctype_qset:
+            self.assertTrue(self.user.has_perm("change_contenttype", obj))
+
+    def test_group_assign_perm_queryset(self):
+        assign_perm("change_contenttype", self.group, self.ctype_qset)
+        assign_perm("delete_contenttype", self.group, self.ctype_qset)
+
+        check = ObjectPermissionChecker(self.group)
+        for obj in self.ctype_qset:
+            self.assertTrue(check.has_perm("change_contenttype", obj))
+            self.assertTrue(check.has_perm("delete_contenttype", obj))
+
     def test_user_assign_perm_global(self):
         perm = assign_perm("contenttypes.change_contenttype", self.user)
         self.assertTrue(self.user.has_perm("contenttypes.change_contenttype"))


### PR DESCRIPTION
I just started using django-guardian and found myself really wanting a function to assign permissions for multiple objects at once. Then I found issue #52 and decided I should write it myself. Anyway, here's what I've come up with.

I'm also working on writing an action for `GuardedModelAdmin` to work with this function, but that'll come later.