### PR TITLE
Add TEMPLATES in example_project settings

### DIFF
--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -100,3 +100,16 @@ PASSWORD_HASHERS = (
 )
 
 AUTH_USER_MODEL = 'core.CustomUser'
+
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': TEMPLATE_DIRS,
+        'OPTIONS': {
+            'debug': TEMPLATE_DEBUG,
+            'loaders': TEMPLATE_LOADERS,
+            'context_processors': TEMPLATE_CONTEXT_PROCESSORS,
+        },
+    },
+]


### PR DESCRIPTION
Hello,

Lack of ```TEMPLATES``` print out in console in Django 1.9.4 during usage ```example_project```:
```
/tmp/django-guardian-env/local/lib/python2.7/site-packages/django/template/utils.py:37: RemovedInDjango110Warning: You haven't defined a TEMPLATES setting. You must do so before upgrading to Django 1.10. Otherwise Django will be unable to load templates.
  "unable to load templates.", RemovedInDjango110Warning)
```

Greetings,