### PR TITLE
Bulk assign permissions for multiple objects

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,8 @@
 Release 1.4.5
+============================
 
-* Added `bulk_assign_perm` and `bulk_remove_perm`
-* `assign_perm` and `bulk_remove_perm` shortcuts accept `Permission` 
-  instance too
+* `assign_perm` and `remove_perm` shortcuts accept `Permission` 
+  instance as `perm` and `QuerySet` as `obj` too
 
 Release 1.4.4 (Apr 04, 2016)
 ============================

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Release 1.4.5
+
+* Added `bulk_assign_perm` and `bulk_remove_perm`
+* `assign_perm` and `bulk_remove_perm` shortcuts accept `Permission` 
+  instance too
+
 Release 1.4.4 (Apr 04, 2016)
 ============================
 

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -72,11 +72,11 @@ class ObjectPermissionChecker(object):
         :param obj: Django model instance for which permission should be checked
 
         """
-        perm = perm.split('.')[-1]
         if self.user and not self.user.is_active:
             return False
         elif self.user and self.user.is_superuser:
             return True
+        perm = perm.split('.')[-1]
         return perm in self.get_perms(obj)
 
     def get_group_filters(self, obj):

--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -5,13 +5,20 @@ from django.contrib.contenttypes.models import ContentType
 
 from guardian.exceptions import ObjectNotPersisted
 from guardian.models import Permission
+from guardian.core import ObjectPermissionChecker
+from django.db.models import Q
 import warnings
-
-# TODO: consolidate UserObjectPermissionManager and
-# GroupObjectPermissionManager
 
 
 class BaseObjectPermissionManager(models.Manager):
+
+    @property
+    def user_or_group_field(self):
+        try:
+            self.model._meta.get_field('user')
+            return 'user'
+        except models.fields.FieldDoesNotExist:
+            return 'group'
 
     def is_generic(self):
         try:
@@ -20,10 +27,7 @@ class BaseObjectPermissionManager(models.Manager):
         except models.fields.FieldDoesNotExist:
             return False
 
-
-class UserObjectPermissionManager(BaseObjectPermissionManager):
-
-    def assign_perm(self, perm, user, obj):
+    def assign_perm(self, perm, user_or_group, obj):
         """
         Assigns permission with given ``perm`` for an instance ``obj`` and
         ``user``.
@@ -38,23 +42,52 @@ class UserObjectPermissionManager(BaseObjectPermissionManager):
         else:
             permission = perm
 
-        kwargs = {'permission': permission, 'user': user}
+        kwargs = {'permission': permission, self.user_or_group_field: user_or_group}
         if self.is_generic():
             kwargs['content_type'] = ctype
             kwargs['object_pk'] = obj.pk
         else:
             kwargs['content_object'] = obj
-        obj_perm, created = self.get_or_create(**kwargs)
+        obj_perm, _ = self.get_or_create(**kwargs)
         return obj_perm
 
-    def assign(self, perm, user, obj):
+    def bulk_assign_perm(self, perm, user_or_group, queryset):
+        """
+        Bulk assigns permissions with given ``perm`` for an objects in ``queryset`` and
+        ``user_or_group``.
+        """
+
+        ctype = ContentType.objects.get_for_model(queryset.model)
+        if not isinstance(perm, Permission):
+            permission = Permission.objects.get(content_type=ctype, codename=perm)
+        else:
+            permission = perm
+
+        checker = ObjectPermissionChecker(user_or_group)
+        checker.prefetch_perms(queryset)
+
+        assigned_perms = []
+        for instance in queryset:
+            if not checker.has_perm(permission.codename, instance):
+                kwargs = {'permission': permission, self.user_or_group_field: user_or_group}
+                if self.is_generic():
+                    kwargs['content_type'] = ctype
+                    kwargs['object_pk'] = instance.pk
+                else:
+                    kwargs['content_object'] = instance
+                assigned_perms.append(self.model(**kwargs))
+        self.model.objects.bulk_create(assigned_perms)
+
+        return assigned_perms
+
+    def assign(self, perm, user_or_group, obj):
         """ Depreciated function name left in for compatibility"""
         warnings.warn("UserObjectPermissionManager method 'assign' is being renamed to 'assign_perm'. Update your code accordingly as old name will be depreciated in 2.0 version.", DeprecationWarning)
-        return self.assign_perm(perm, user, obj)
+        return self.assign_perm(perm, user_or_group, obj)
 
-    def remove_perm(self, perm, user, obj):
+    def remove_perm(self, perm, user_or_group, obj):
         """
-        Removes permission ``perm`` for an instance ``obj`` and given ``user``.
+        Removes permission ``perm`` for an instance ``obj`` and given ``user_or_group``.
 
         Please note that we do NOT fetch object permission from database - we
         use ``Queryset.delete`` method for removing it. Main implication of this
@@ -63,65 +96,47 @@ class UserObjectPermissionManager(BaseObjectPermissionManager):
         if getattr(obj, 'pk', None) is None:
             raise ObjectNotPersisted("Object %s needs to be persisted first"
                                      % obj)
-        filters = {
-            'permission__codename': perm,
-            'permission__content_type': ContentType.objects.get_for_model(obj),
-            'user': user,
-        }
-        if self.is_generic():
-            filters['object_pk'] = obj.pk
+
+        filters = Q(**{self.user_or_group_field: user_or_group})
+
+        if isinstance(perm, Permission):
+            filters &= Q(permission=perm)
         else:
-            filters['content_object__pk'] = obj.pk
-        self.filter(**filters).delete()
+            filters &= Q(permission__codename=perm,
+                         permission__content_type=ContentType.objects.get_for_model(obj))
+
+        if self.is_generic():
+            filters &= Q(object_pk=obj.pk)
+        else:
+            filters &= Q(content_object__pk=obj.pk)
+        return self.filter(filters).delete()
+
+    def bulk_remove_perm(self, perm, user_or_group, queryset):
+        """
+        Removes permission ``perm`` for a ``queryset`` and given ``user_or_group``.
+
+        Please note that we do NOT fetch object permission from database - we
+        use ``Queryset.delete`` method for removing it. Main implication of this
+        is that ``post_delete`` signals would NOT be fired.
+        """
+        filters = Q(**{self.user_or_group_field: user_or_group})
+
+        if self.is_generic():
+            if isinstance(perm, Permission):
+                filters &= Q(permission=perm)
+            else:
+                ctype = ContentType.objects.get_for_model(queryset.model)
+                filters &= Q(permission__codename=perm,
+                             permission__content_type=ctype)
+        else:
+            filters &= Q(content_object__in=queryset)
+
+        return self.filter(filters).delete()
+
+
+class UserObjectPermissionManager(BaseObjectPermissionManager):
+    pass
 
 
 class GroupObjectPermissionManager(BaseObjectPermissionManager):
-
-    def assign_perm(self, perm, group, obj):
-        """
-        Assigns permission with given ``perm`` for an instance ``obj`` and
-        ``group``.
-        """
-        if getattr(obj, 'pk', None) is None:
-            raise ObjectNotPersisted("Object %s needs to be persisted first"
-                                     % obj)
-
-        ctype = ContentType.objects.get_for_model(obj)
-        if not isinstance(perm, Permission):
-            ctype = ContentType.objects.get_for_model(obj)
-            permission = Permission.objects.get(content_type=ctype, codename=perm)
-        else:
-            permission = perm
-
-        kwargs = {'permission': permission, 'group': group}
-        if self.is_generic():
-            kwargs['content_type'] = ctype
-            kwargs['object_pk'] = obj.pk
-        else:
-            kwargs['content_object'] = obj
-        obj_perm, created = self.get_or_create(**kwargs)
-        return obj_perm
-
-    def assign(self, perm, user, obj):
-        """ Depreciated function name left in for compatibility"""
-        warnings.warn("UserObjectPermissionManager method 'assign' is being renamed to 'assign_perm'. Update your code accordingly as old name will be depreciated in 2.0 version.", DeprecationWarning)
-        return self.assign_perm(perm, user, obj)
-
-    def remove_perm(self, perm, group, obj):
-        """
-        Removes permission ``perm`` for an instance ``obj`` and given ``group``.
-        """
-        if getattr(obj, 'pk', None) is None:
-            raise ObjectNotPersisted("Object %s needs to be persisted first"
-                                     % obj)
-        filters = {
-            'permission__codename': perm,
-            'permission__content_type': ContentType.objects.get_for_model(obj),
-            'group': group,
-        }
-        if self.is_generic():
-            filters['object_pk'] = obj.pk
-        else:
-            filters['content_object__pk'] = obj.pk
-
-        self.filter(**filters).delete()
+    pass

--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -31,8 +31,12 @@ class UserObjectPermissionManager(BaseObjectPermissionManager):
         if getattr(obj, 'pk', None) is None:
             raise ObjectNotPersisted("Object %s needs to be persisted first"
                                      % obj)
+
         ctype = ContentType.objects.get_for_model(obj)
-        permission = Permission.objects.get(content_type=ctype, codename=perm)
+        if not isinstance(perm, Permission):
+            permission = Permission.objects.get(content_type=ctype, codename=perm)
+        else:
+            permission = perm
 
         kwargs = {'permission': permission, 'user': user}
         if self.is_generic():
@@ -81,8 +85,13 @@ class GroupObjectPermissionManager(BaseObjectPermissionManager):
         if getattr(obj, 'pk', None) is None:
             raise ObjectNotPersisted("Object %s needs to be persisted first"
                                      % obj)
+
         ctype = ContentType.objects.get_for_model(obj)
-        permission = Permission.objects.get(content_type=ctype, codename=perm)
+        if not isinstance(perm, Permission):
+            ctype = ContentType.objects.get_for_model(obj)
+            permission = Permission.objects.get(content_type=ctype, codename=perm)
+        else:
+            permission = perm
 
         kwargs = {'permission': permission, 'group': group}
         if self.is_generic():

--- a/guardian/mixins.py
+++ b/guardian/mixins.py
@@ -156,8 +156,8 @@ class PermissionRequiredMixin(object):
     def get_permission_object(self):
         if hasattr(self, 'permission_object'):
             return self.permission_object
-        return (hasattr(self, 'get_object') and self.get_object()
-                or getattr(self, 'object', None))
+        return (hasattr(self, 'get_object') and self.get_object() or
+                getattr(self, 'object', None))
 
     def check_permissions(self, request):
         """

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -89,7 +89,8 @@ def assign_perm(perm, user_or_group, obj=None):
             group.permissions.add(perm)
             return perm
 
-    perm = perm.split('.')[-1]
+    if not isinstance(perm, Permission):
+        perm = perm.split('.')[-1]
 
     if user:
         model = get_user_obj_perms_model(obj)
@@ -160,7 +161,9 @@ def remove_perm(perm, user_or_group=None, obj=None):
             group.permissions.remove(perm)
             return
 
-    perm = perm.split('.')[-1]
+    if not isinstance(perm, Permission):
+        perm = perm.split('.')[-1]
+
     if user:
         model = get_user_obj_perms_model(obj)
         model.objects.remove_perm(perm, user, obj)

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -25,7 +25,7 @@ import warnings
 
 def assign_perm(perm, user_or_group, obj=None):
     """
-    Assigns permission to user/group and object pair.
+    Assigns permission to user/group and object pair(s).
 
     :param perm: proper permission for given ``obj``, as string (in format:
       ``app_label.codename`` or ``codename``). If ``obj`` is not given, must
@@ -35,8 +35,9 @@ def assign_perm(perm, user_or_group, obj=None):
       passing any other object would raise
       ``guardian.exceptions.NotUserNorGroup`` exception
 
-    :param obj: persisted Django's ``Model`` instance or ``None`` if assigning
-      global permission. Default is ``None``.
+    :param obj: persisted Django's ``Model`` instance, QuerySet of ``Model``
+      instances, or ``None`` if assigning global permission. Default is
+      ``None``.
 
     We can assign permission for ``Model`` instance for specific user:
 
@@ -56,6 +57,15 @@ def assign_perm(perm, user_or_group, obj=None):
     >>> user.groups.add(group)
     >>> assign_perm("delete_site", group, site)
     <GroupObjectPermission: example.com | joe-group | delete_site>
+    >>> user.has_perm("delete_site", site)
+    True
+
+    ... or the same for a queryset:
+
+    >>> sites = Site.objects.all()
+    >>> assign_perm("delete_site", user, sites)
+    [<GroupObjectPermission: example.org | joe | delete_site>, ...]
+    >>> site = Site.objects.get(domain='example.org')
     >>> user.has_perm("delete_site", site)
     True
 
@@ -115,7 +125,7 @@ def assign(perm, user_or_group, obj=None):
 
 def remove_perm(perm, user_or_group=None, obj=None):
     """
-    Removes permission from user/group and object pair.
+    Removes permission from user/group and object pair(s).
 
     :param perm: proper permission for given ``obj``, as string (in format:
       ``app_label.codename`` or ``codename``). If ``obj`` is not given, must
@@ -125,8 +135,9 @@ def remove_perm(perm, user_or_group=None, obj=None):
       passing any other object would raise
       ``guardian.exceptions.NotUserNorGroup`` exception
 
-    :param obj: persisted Django's ``Model`` instance or ``None`` if assigning
-      global permission. Default is ``None``.
+    :param obj: persisted Django's ``Model`` instance, QuerySet of ``Model``
+      instances, or ``None`` if assigning global permission. Default is
+      ``None``.
 
     """
     user, group = get_identity(user_or_group)

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -144,13 +144,23 @@ def remove_perm(perm, user_or_group=None, obj=None):
         elif group:
             group.permissions.remove(perm)
             return
+
     perm = perm.split('.')[-1]
-    if user:
-        model = get_user_obj_perms_model(obj)
-        model.objects.remove_perm(perm, user, obj)
-    if group:
-        model = get_group_obj_perms_model(obj)
-        model.objects.remove_perm(perm, group, obj)
+    try:
+        for instance in obj:
+            if user:
+                model = get_user_obj_perms_model(instance)
+            if group:
+                model = get_group_obj_perms_model(instance)
+
+            model.objects.remove_perm(perm, user or group, instance)
+    except TypeError:
+        if user:
+            model = get_user_obj_perms_model(obj)
+            model.objects.remove_perm(perm, user, obj)
+        if group:
+            model = get_group_obj_perms_model(obj)
+            model.objects.remove_perm(perm, group, obj)
 
 
 def get_perms(user_or_group, obj):

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -86,13 +86,25 @@ def assign_perm(perm, user_or_group, obj=None):
         if group:
             group.permissions.add(perm)
             return perm
+
     perm = perm.split('.')[-1]
-    if user:
-        model = get_user_obj_perms_model(obj)
-        return model.objects.assign_perm(perm, user, obj)
-    if group:
-        model = get_group_obj_perms_model(obj)
-        return model.objects.assign_perm(perm, group, obj)
+    try:
+        assigned_perms = []
+        for instance in obj:
+            if user:
+                model = get_user_obj_perms_model(instance)
+            if group:
+                model = get_group_obj_perms_model(instance)
+
+            assigned_perms.append(model.objects.assign_perm(perm, user or group, instance))
+        return assigned_perms
+    except TypeError:
+        if user:
+            model = get_user_obj_perms_model(obj)
+            return model.objects.assign_perm(perm, user, obj)
+        if group:
+            model = get_group_obj_perms_model(obj)
+            return model.objects.assign_perm(perm, group, obj)
 
 
 def assign(perm, user_or_group, obj=None):

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -42,6 +42,7 @@ class ObjectPermissionTestCase(TestCase):
         self.user.groups.add(self.group)
         self.ctype = ContentType.objects.create(
             model='bar', app_label='fake-for-guardian-tests')
+        self.ctype_qset = ContentType.objects.filter(model='bar', app_label='fake-for-guardian-tests')
         self.anonymous_user = User.objects.get(
             username=guardian_settings.ANONYMOUS_USER_NAME)
 

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -42,9 +42,16 @@ class ObjectPermissionTestCase(TestCase):
         self.user.groups.add(self.group)
         self.ctype = ContentType.objects.create(
             model='bar', app_label='fake-for-guardian-tests')
-        self.ctype_qset = ContentType.objects.filter(model='bar', app_label='fake-for-guardian-tests')
+        self.ctype_qset = ContentType.objects.filter(model='bar',
+                                                     app_label='fake-for-guardian-tests')
         self.anonymous_user = User.objects.get(
             username=guardian_settings.ANONYMOUS_USER_NAME)
+
+    def get_permission(self, codename, app_label=None):
+        qs = Permission.objects
+        if app_label:
+            qs = qs.filter(content_type__app_label=app_label)
+        return Permission.objects.get(codename=codename)
 
 
 class ObjectPermissionCheckerTest(ObjectPermissionTestCase):

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -11,7 +11,9 @@ from guardian.compat import get_user_model
 from guardian.compat import get_user_permission_full_codename, get_model_name
 from guardian.shortcuts import assign
 from guardian.shortcuts import assign_perm
+from guardian.shortcuts import bulk_assign_perm
 from guardian.shortcuts import remove_perm
+from guardian.shortcuts import bulk_remove_perm
 from guardian.shortcuts import get_perms
 from guardian.shortcuts import get_user_perms
 from guardian.shortcuts import get_group_perms
@@ -81,15 +83,15 @@ class AssignPermTest(ObjectPermissionTestCase):
         self.assertTrue(check.has_perm("change_contenttype", self.ctype))
         self.assertTrue(check.has_perm("delete_contenttype", self.ctype))
 
-    def test_user_assign_perm_queryset(self):
-        assign_perm("change_contenttype", self.user, self.ctype_qset)
-        assign_perm("change_contenttype", self.group, self.ctype_qset)
+    def test_user_bulk_assign_perm(self):
+        bulk_assign_perm("change_contenttype", self.user, self.ctype_qset)
+        bulk_assign_perm("change_contenttype", self.group, self.ctype_qset)
         for obj in self.ctype_qset:
             self.assertTrue(self.user.has_perm("change_contenttype", obj))
 
-    def test_group_assign_perm_queryset(self):
-        assign_perm("change_contenttype", self.group, self.ctype_qset)
-        assign_perm("delete_contenttype", self.group, self.ctype_qset)
+    def test_group_bulk_assign_perm(self):
+        bulk_assign_perm("change_contenttype", self.group, self.ctype_qset)
+        bulk_assign_perm("delete_contenttype", self.group, self.ctype_qset)
 
         check = ObjectPermissionChecker(self.group)
         for obj in self.ctype_qset:
@@ -145,15 +147,15 @@ class RemovePermTest(ObjectPermissionTestCase):
         check = ObjectPermissionChecker(self.group)
         self.assertFalse(check.has_perm("change_contenttype", self.ctype))
 
-    def test_user_remove_perm_queryset(self):
-        assign_perm("change_contenttype", self.user, self.ctype_qset)
-        remove_perm("change_contenttype", self.user, self.ctype_qset)
+    def test_user_bulk_remove_perm(self):
+        bulk_assign_perm("change_contenttype", self.user, self.ctype_qset)
+        bulk_remove_perm("change_contenttype", self.user, self.ctype_qset)
         for obj in self.ctype_qset:
             self.assertFalse(self.user.has_perm("change_contenttype", obj))
 
-    def test_group_remove_perm_queryset(self):
-        assign_perm("change_contenttype", self.group, self.ctype_qset)
-        remove_perm("change_contenttype", self.group, self.ctype_qset)
+    def test_group_bulk_remove_perm(self):
+        bulk_assign_perm("change_contenttype", self.group, self.ctype_qset)
+        bulk_remove_perm("change_contenttype", self.group, self.ctype_qset)
 
         check = ObjectPermissionChecker(self.group)
         for obj in self.ctype_qset:

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -11,9 +11,7 @@ from guardian.compat import get_user_model
 from guardian.compat import get_user_permission_full_codename, get_model_name
 from guardian.shortcuts import assign
 from guardian.shortcuts import assign_perm
-from guardian.shortcuts import bulk_assign_perm
 from guardian.shortcuts import remove_perm
-from guardian.shortcuts import bulk_remove_perm
 from guardian.shortcuts import get_perms
 from guardian.shortcuts import get_user_perms
 from guardian.shortcuts import get_group_perms
@@ -88,19 +86,19 @@ class AssignPermTest(ObjectPermissionTestCase):
         self.assertTrue(check.has_perm("change_contenttype", self.ctype))
         self.assertTrue(check.has_perm("delete_contenttype", self.ctype))
 
-    def test_user_bulk_assign_perm(self):
-        bulk_assign_perm("add_contenttype", self.user, self.ctype_qset)
-        bulk_assign_perm("change_contenttype", self.group, self.ctype_qset)
-        bulk_assign_perm(self.get_permission("delete_contenttype"), self.user, self.ctype_qset)
+    def test_user_assign_perm_queryset(self):
+        assign_perm("add_contenttype", self.user, self.ctype_qset)
+        assign_perm("change_contenttype", self.group, self.ctype_qset)
+        assign_perm(self.get_permission("delete_contenttype"), self.user, self.ctype_qset)
         for obj in self.ctype_qset:
             self.assertTrue(self.user.has_perm("add_contenttype", obj))
             self.assertTrue(self.user.has_perm("change_contenttype", obj))
             self.assertTrue(self.user.has_perm("delete_contenttype", obj))
 
-    def test_group_bulk_assign_perm(self):
-        bulk_assign_perm("add_contenttype", self.group, self.ctype_qset)
-        bulk_assign_perm("change_contenttype", self.group, self.ctype_qset)
-        bulk_assign_perm(self.get_permission("delete_contenttype"), self.group, self.ctype_qset)
+    def test_group_assign_perm_queryset(self):
+        assign_perm("add_contenttype", self.group, self.ctype_qset)
+        assign_perm("change_contenttype", self.group, self.ctype_qset)
+        assign_perm(self.get_permission("delete_contenttype"), self.group, self.ctype_qset)
 
         check = ObjectPermissionChecker(self.group)
         for obj in self.ctype_qset:
@@ -157,15 +155,15 @@ class RemovePermTest(ObjectPermissionTestCase):
         check = ObjectPermissionChecker(self.group)
         self.assertFalse(check.has_perm("change_contenttype", self.ctype))
 
-    def test_user_bulk_remove_perm(self):
-        bulk_assign_perm("change_contenttype", self.user, self.ctype_qset)
-        bulk_remove_perm("change_contenttype", self.user, self.ctype_qset)
+    def test_user_remove_perm_queryset(self):
+        assign_perm("change_contenttype", self.user, self.ctype_qset)
+        remove_perm("change_contenttype", self.user, self.ctype_qset)
         for obj in self.ctype_qset:
             self.assertFalse(self.user.has_perm("change_contenttype", obj))
 
-    def test_group_bulk_remove_perm(self):
-        bulk_assign_perm("change_contenttype", self.group, self.ctype_qset)
-        bulk_remove_perm("change_contenttype", self.group, self.ctype_qset)
+    def test_group_remove_perm_queryset(self):
+        assign_perm("change_contenttype", self.group, self.ctype_qset)
+        remove_perm("change_contenttype", self.group, self.ctype_qset)
 
         check = ObjectPermissionChecker(self.group)
         for obj in self.ctype_qset:

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -145,6 +145,20 @@ class RemovePermTest(ObjectPermissionTestCase):
         check = ObjectPermissionChecker(self.group)
         self.assertFalse(check.has_perm("change_contenttype", self.ctype))
 
+    def test_user_remove_perm_queryset(self):
+        assign_perm("change_contenttype", self.user, self.ctype_qset)
+        remove_perm("change_contenttype", self.user, self.ctype_qset)
+        for obj in self.ctype_qset:
+            self.assertFalse(self.user.has_perm("change_contenttype", obj))
+
+    def test_group_remove_perm_queryset(self):
+        assign_perm("change_contenttype", self.group, self.ctype_qset)
+        remove_perm("change_contenttype", self.group, self.ctype_qset)
+
+        check = ObjectPermissionChecker(self.group)
+        for obj in self.ctype_qset:
+            self.assertFalse(check.has_perm("change_contenttype", obj))
+
     def test_user_remove_perm_global(self):
         # assign perm first
         perm = "contenttypes.change_contenttype"

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -71,30 +71,40 @@ class AssignPermTest(ObjectPermissionTestCase):
                           user_or_group=self.user)
 
     def test_user_assign_perm(self):
-        assign_perm("change_contenttype", self.user, self.ctype)
+        assign_perm("add_contenttype", self.user, self.ctype)
         assign_perm("change_contenttype", self.group, self.ctype)
+        assign_perm(self.get_permission("delete_contenttype"), self.user, self.ctype)
+        self.assertTrue(self.user.has_perm("add_contenttype", self.ctype))
         self.assertTrue(self.user.has_perm("change_contenttype", self.ctype))
+        self.assertTrue(self.user.has_perm("delete_contenttype", self.ctype))
 
     def test_group_assign_perm(self):
+        assign_perm("add_contenttype", self.group, self.ctype)
         assign_perm("change_contenttype", self.group, self.ctype)
-        assign_perm("delete_contenttype", self.group, self.ctype)
+        assign_perm(self.get_permission("delete_contenttype"), self.group, self.ctype)
 
         check = ObjectPermissionChecker(self.group)
+        self.assertTrue(check.has_perm("add_contenttype", self.ctype))
         self.assertTrue(check.has_perm("change_contenttype", self.ctype))
         self.assertTrue(check.has_perm("delete_contenttype", self.ctype))
 
     def test_user_bulk_assign_perm(self):
-        bulk_assign_perm("change_contenttype", self.user, self.ctype_qset)
+        bulk_assign_perm("add_contenttype", self.user, self.ctype_qset)
         bulk_assign_perm("change_contenttype", self.group, self.ctype_qset)
+        bulk_assign_perm(self.get_permission("delete_contenttype"), self.user, self.ctype_qset)
         for obj in self.ctype_qset:
+            self.assertTrue(self.user.has_perm("add_contenttype", obj))
             self.assertTrue(self.user.has_perm("change_contenttype", obj))
+            self.assertTrue(self.user.has_perm("delete_contenttype", obj))
 
     def test_group_bulk_assign_perm(self):
+        bulk_assign_perm("add_contenttype", self.group, self.ctype_qset)
         bulk_assign_perm("change_contenttype", self.group, self.ctype_qset)
-        bulk_assign_perm("delete_contenttype", self.group, self.ctype_qset)
+        bulk_assign_perm(self.get_permission("delete_contenttype"), self.group, self.ctype_qset)
 
         check = ObjectPermissionChecker(self.group)
         for obj in self.ctype_qset:
+            self.assertTrue(check.has_perm("add_contenttype", obj))
             self.assertTrue(check.has_perm("change_contenttype", obj))
             self.assertTrue(check.has_perm("delete_contenttype", obj))
 

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -81,6 +81,21 @@ class AssignPermTest(ObjectPermissionTestCase):
         self.assertTrue(check.has_perm("change_contenttype", self.ctype))
         self.assertTrue(check.has_perm("delete_contenttype", self.ctype))
 
+    def test_user_assign_perm_queryset(self):
+        assign_perm("change_contenttype", self.user, self.ctype_qset)
+        assign_perm("change_contenttype", self.group, self.ctype_qset)
+        for obj in self.ctype_qset:
+            self.assertTrue(self.user.has_perm("change_contenttype", obj))
+
+    def test_group_assign_perm_queryset(self):
+        assign_perm("change_contenttype", self.group, self.ctype_qset)
+        assign_perm("delete_contenttype", self.group, self.ctype_qset)
+
+        check = ObjectPermissionChecker(self.group)
+        for obj in self.ctype_qset:
+            self.assertTrue(check.has_perm("change_contenttype", obj))
+            self.assertTrue(check.has_perm("delete_contenttype", obj))
+
     def test_user_assign_perm_global(self):
         perm = assign_perm("contenttypes.change_contenttype", self.user)
         self.assertTrue(self.user.has_perm("contenttypes.change_contenttype"))


### PR DESCRIPTION
Hello,

I updated code from #432 made by @phinjensen to:
- consolidate UserObjectPermissionManager and GroupObjectPermissionManager,
- add efficient implementation of ```assign_perm``` and ```remove_perm``` for bulk action,
- accept ```Permission``` instance as argument for ```assign_perm``` and ```remove_perm```` (Due some working idea on implementations bulk_assign_perm and leave these good changes.).

Greetings,