### PR TITLE
Make UserManage form overridable

### DIFF
--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -178,8 +178,8 @@ class GuardedModelAdminMixin(object):
         )
 
         if request.method == 'POST' and 'submit_manage_user' in request.POST:
-            user_form = self.get_obj_perms_user_select_form()(request.POST)
-            group_form = self.get_obj_perms_group_select_form()(request.POST)
+            user_form = self.get_obj_perms_user_select_form(request)(request.POST)
+            group_form = self.get_obj_perms_group_select_form(request)(request.POST)
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
@@ -193,8 +193,8 @@ class GuardedModelAdminMixin(object):
                 )
                 return redirect(url)
         elif request.method == 'POST' and 'submit_manage_group' in request.POST:
-            user_form = self.get_obj_perms_user_select_form()()
-            group_form = self.get_obj_perms_group_select_form()(request.POST)
+            user_form = self.get_obj_perms_user_select_form(request)()
+            group_form = self.get_obj_perms_group_select_form(request)(request.POST)
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
@@ -208,8 +208,8 @@ class GuardedModelAdminMixin(object):
                 )
                 return redirect(url)
         else:
-            user_form = self.get_obj_perms_user_select_form()()
-            group_form = self.get_obj_perms_group_select_form()()
+            user_form = self.get_obj_perms_user_select_form(request)()
+            group_form = self.get_obj_perms_group_select_form(request)()
 
         context = self.get_obj_perms_base_context(request, obj)
         context['users_perms'] = users_perms
@@ -246,7 +246,7 @@ class GuardedModelAdminMixin(object):
 
         user = get_object_or_404(get_user_model(), pk=user_id)
         obj = get_object_or_404(self.get_queryset(request), pk=object_pk)
-        form_class = self.get_obj_perms_manage_user_form()
+        form_class = self.get_obj_perms_manage_user_form(request)
         form = form_class(user, obj, request.POST or None)
 
         if request.method == 'POST' and form.is_valid():
@@ -287,14 +287,14 @@ class GuardedModelAdminMixin(object):
             return 'admin/guardian/contrib/grappelli/obj_perms_manage_user.html'
         return self.obj_perms_manage_user_template
 
-    def get_obj_perms_user_select_form(self):
+    def get_obj_perms_user_select_form(self, request):
         """
         Returns form class for selecting a user for permissions management.  By
         default :form:`UserManage` is returned.
         """
         return UserManage
 
-    def get_obj_perms_group_select_form(self):
+    def get_obj_perms_group_select_form(self, request):
         """
         Returns form class for selecting a group for permissions management.  By
         default :form:`GroupManage` is returned.
@@ -302,7 +302,7 @@ class GuardedModelAdminMixin(object):
         return GroupManage
 
 
-    def get_obj_perms_manage_user_form(self):
+    def get_obj_perms_manage_user_form(self, request):
         """
         Returns form class for user object permissions management.  By default
         :form:`AdminUserObjectPermissionsForm` is returned.
@@ -319,7 +319,7 @@ class GuardedModelAdminMixin(object):
 
         group = get_object_or_404(Group, id=group_id)
         obj = get_object_or_404(self.get_queryset(request), pk=object_pk)
-        form_class = self.get_obj_perms_manage_group_form()
+        form_class = self.get_obj_perms_manage_group_form(request)
         form = form_class(group, obj, request.POST or None)
 
         if request.method == 'POST' and form.is_valid():
@@ -360,7 +360,7 @@ class GuardedModelAdminMixin(object):
             return 'admin/guardian/contrib/grappelli/obj_perms_manage_group.html'
         return self.obj_perms_manage_group_template
 
-    def get_obj_perms_manage_group_form(self):
+    def get_obj_perms_manage_group_form(self, request):
         """
         Returns form class for group object permissions management.  By default
         :form:`AdminGroupObjectPermissionsForm` is returned.

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -193,7 +193,7 @@ class GuardedModelAdminMixin(object):
                 )
                 return redirect(url)
         elif request.method == 'POST' and 'submit_manage_group' in request.POST:
-            user_form = self.get_obj_perms_user_select_form(request)()
+            user_form = self.get_obj_perms_user_select_form(request)(request.POST)
             group_form = self.get_obj_perms_group_select_form(request)(request.POST)
             info = (
                 self.admin_site.name,

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -178,7 +178,7 @@ class GuardedModelAdminMixin(object):
         )
 
         if request.method == 'POST' and 'submit_manage_user' in request.POST:
-            user_form = UserManage(request.POST)
+            user_form = self.get_obj_perms_user_select_form()(request.POST)
             group_form = GroupManage()
             info = (
                 self.admin_site.name,
@@ -193,7 +193,7 @@ class GuardedModelAdminMixin(object):
                 )
                 return redirect(url)
         elif request.method == 'POST' and 'submit_manage_group' in request.POST:
-            user_form = UserManage()
+            user_form = self.get_obj_perms_user_select_form()()
             group_form = GroupManage(request.POST)
             info = (
                 self.admin_site.name,
@@ -208,7 +208,7 @@ class GuardedModelAdminMixin(object):
                 )
                 return redirect(url)
         else:
-            user_form = UserManage()
+            user_form = self.get_obj_perms_user_select_form()()
             group_form = GroupManage()
 
         context = self.get_obj_perms_base_context(request, obj)
@@ -286,6 +286,13 @@ class GuardedModelAdminMixin(object):
         if 'grappelli' in settings.INSTALLED_APPS:
             return 'admin/guardian/contrib/grappelli/obj_perms_manage_user.html'
         return self.obj_perms_manage_user_template
+
+    def get_obj_perms_user_select_form(self):
+        """
+        Returns form class for selecting a user for permissions management.  By
+        default :form:`UserManage` is returned.
+        """
+        return UserManage
 
     def get_obj_perms_manage_user_form(self):
         """

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -179,7 +179,7 @@ class GuardedModelAdminMixin(object):
 
         if request.method == 'POST' and 'submit_manage_user' in request.POST:
             user_form = self.get_obj_perms_user_select_form()(request.POST)
-            group_form = GroupManage()
+            group_form = self.get_obj_perms_group_select_form()(request.POST)
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
@@ -194,7 +194,7 @@ class GuardedModelAdminMixin(object):
                 return redirect(url)
         elif request.method == 'POST' and 'submit_manage_group' in request.POST:
             user_form = self.get_obj_perms_user_select_form()()
-            group_form = GroupManage(request.POST)
+            group_form = self.get_obj_perms_group_select_form()(request.POST)
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
@@ -209,7 +209,7 @@ class GuardedModelAdminMixin(object):
                 return redirect(url)
         else:
             user_form = self.get_obj_perms_user_select_form()()
-            group_form = GroupManage()
+            group_form = self.get_obj_perms_group_select_form()()
 
         context = self.get_obj_perms_base_context(request, obj)
         context['users_perms'] = users_perms
@@ -293,6 +293,14 @@ class GuardedModelAdminMixin(object):
         default :form:`UserManage` is returned.
         """
         return UserManage
+
+    def get_obj_perms_group_select_form(self):
+        """
+        Returns form class for selecting a group for permissions management.  By
+        default :form:`GroupManage` is returned.
+        """
+        return GroupManage
+
 
     def get_obj_perms_manage_user_form(self):
         """

--- a/guardian/testapp/tests/test_admin.py
+++ b/guardian/testapp/tests/test_admin.py
@@ -320,7 +320,12 @@ class GuardedModelAdminTests(TestCase):
     def test_obj_perms_manage_user_form_attr(self):
         attrs = {'obj_perms_manage_user_form': forms.Form}
         gma = self._get_gma(attrs=attrs)
-        self.assertTrue(gma.get_obj_perms_manage_user_form(), forms.Form)
+        self.assertTrue(issubclass(gma.get_obj_perms_manage_user_form(None), forms.Form))
+
+    def test_obj_perms_user_select_form_attr(self):
+        attrs = {'obj_perms_user_select_form': forms.Form}
+        gma = self._get_gma(attrs=attrs)
+        self.assertTrue(issubclass(gma.get_obj_perms_user_select_form(None), forms.Form))
 
     def test_obj_perms_manage_group_template_attr(self):
         attrs = {'obj_perms_manage_group_template': 'foobar.html'}
@@ -331,7 +336,12 @@ class GuardedModelAdminTests(TestCase):
     def test_obj_perms_manage_group_form_attr(self):
         attrs = {'obj_perms_manage_group_form': forms.Form}
         gma = self._get_gma(attrs=attrs)
-        self.assertTrue(gma.get_obj_perms_manage_group_form(), forms.Form)
+        self.assertTrue(issubclass(gma.get_obj_perms_manage_group_form(None), forms.Form))
+
+    def test_obj_perms_group_select_form_attr(self):
+        attrs = {'obj_perms_group_select_form': forms.Form}
+        gma = self._get_gma(attrs=attrs)
+        self.assertTrue(issubclass(gma.get_obj_perms_group_select_form(None), forms.Form))
 
     def test_user_can_acces_owned_objects_only(self):
         attrs = {


### PR DESCRIPTION
This allows simpler user select forms (for instance a `ModelChoiceField`).

It's a fairly simple change, but I think being able to customize the `UserManage` form without monkey-patching, or copy-pasting the whole method is probably a good idea.