### PR TITLE
Upgraded Grappelli templates breadcrumbs block to new Django 1.9 and …

### DIFF
--- a/guardian/templates/admin/guardian/contrib/grappelli/field.html
+++ b/guardian/templates/admin/guardian/contrib/grappelli/field.html
@@ -11,13 +11,6 @@
     {% endif %}
     {% if field.help_text %}<p class="grp-help">{{ field.help_text|safe }}</p>{% endif %}
     {{ field.errors }}
-    {% if field.errors %}
-        <ul class="errorlist">
-            {% for error in field.errors %}
-            <li>{{ error }}</li>
-            {% endfor %}
-        </ul>
-    {% endif %}
         </div>
     </div>
 </div>

--- a/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage.html
+++ b/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage.html
@@ -2,16 +2,28 @@
 {% load i18n %}
 {% load guardian_tags %}
 {% load admin_static %}
+{% load admin_urls %}
 
-{% block breadcrumbs %}{% if not is_popup %}
+{% block breadcrumbs %}
 <ul>
-    <li><a href="../../../../">{% trans "Home" %}</a></li>
-    <li><a href="../../../">{% trans app_label|capfirst|escape %}</a></li>
-    <li>{% if has_change_permission %}<a href="../../">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}</li>
-    <li>{% if has_change_permission %}<a href="../">{{ original|truncatewords:"18" }}</a>{% else %}{{ original|truncatewords:"18" }}{% endif %}</li>
-    <li>{% trans "Object permissions" %}</li>
+    <li><a href="{% url 'admin:index' %}">{% trans 'Home' %}</a></li>
+    <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a></li>
+    {% if has_change_permission %}
+        <li>
+            {% url opts|admin_urlname:'changelist' as changelist_url %}
+            <a href="{% add_preserved_filters changelist_url %}">{{ opts.verbose_name_plural|capfirst }}</a>
+        </li>
+        <li>
+            {% url opts|admin_urlname:'change' object.pk|admin_urlquote as object_url %}
+            <a href="{% add_preserved_filters object_url %}">{{ object|truncatewords:"18" }}</a>
+        </li>
+    {% else %}
+        <li>{{ opts.verbose_name_plural|capfirst }}</li>
+        <li>{{ original|truncatewords:"18" }}</li>
+    {% endif %}
+    <li>{% trans 'Object permissions' %}</li>
 </ul>
-{% endif %}{% endblock %}
+{% endblock %}
 
 {% block content %}
 <form action="." method="post">
@@ -137,5 +149,3 @@
     </div>
 </form>
 {% endblock %}
-
-

--- a/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage_group.html
+++ b/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage_group.html
@@ -1,5 +1,6 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
+{% load admin_urls %}
 
 {% block extrahead %}{{ block.super }}
 {{ form.media }}
@@ -7,15 +8,29 @@
 
 {% block breadcrumbs %}{% if not is_popup %}
 <ul>
-    <li><a href="../../../../../../">{% trans "Home" %}</a></li>
-    <li><a href="../../../../../">{% trans app_label|capfirst|escape %}</a></li>
-    <li>{% if has_change_permission %}<a href="../../../../">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}</li>
-    <li>{% if has_change_permission %}<a href="../../../">{{ original|truncatewords:"18" }}</a>{% else %}{{ original|truncatewords:"18" }}{% endif %}</li>
-    <li>{% if has_change_permission %}<a href="../../">{% trans "Object permissions" %}</a>{% else %}{% trans "Object permissions" %}{% endif %}</li>
+    <li><a href="{% url 'admin:index' %}">{% trans 'Home' %}</a></li>
+    <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a></li>
+    {% if has_change_permission %}
+        <li>
+            {% url opts|admin_urlname:'changelist' as changelist_url %}
+            <a href="{% add_preserved_filters changelist_url %}">{{ opts.verbose_name_plural|capfirst }}</a>
+        </li>
+        <li>
+            {% url opts|admin_urlname:'change' object.pk|admin_urlquote as object_url %}
+            <a href="{% add_preserved_filters object_url %}">{{ object|truncatewords:"18" }}</a>
+        </li>
+        <li>
+            {% url opts|admin_urlname:'permissions' object.pk|admin_urlquote as permissions_url %}
+            <a href="{% add_preserved_filters permissions_url %}">{% trans "Object permissions" %}</a>
+        </li>
+    {% else %}
+        <li>{{ opts.verbose_name_plural|capfirst }}</li>
+        <li>{{ original|truncatewords:"18" }}</li>
+        <li>{% trans "Object permissions" %}</li>
+    {% endif %}
     <li>{% trans "Manage group" %}: {{ group_obj|truncatewords:"18" }}</li>
 </ul>
 {% endif %}{% endblock %}
-
 
 {% block content %}
 <form action="." method="post">

--- a/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage_user.html
+++ b/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage_user.html
@@ -1,5 +1,6 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
+{% load admin_urls %}
 
 {% block extrahead %}{{ block.super }}
 {{ form.media }}
@@ -7,15 +8,29 @@
 
 {% block breadcrumbs %}{% if not is_popup %}
 <ul>
-    <li><a href="../../../../../../">{% trans "Home" %}</a></li>
-    <li><a href="../../../../../">{% trans app_label|capfirst|escape %}</a></li>
-    <li>{% if has_change_permission %}<a href="../../../../">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}</li>
-    <li>{% if has_change_permission %}<a href="../../../">{{ original|truncatewords:"18" }}</a>{% else %}{{ original|truncatewords:"18" }}{% endif %}</li>
-    <li>{% if has_change_permission %}<a href="../../">{% trans "Object permissions" %}</a>{% else %}{% trans "Object permissions" %}{% endif %}</li>
+    <li><a href="{% url 'admin:index' %}">{% trans 'Home' %}</a></li>
+    <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a></li>
+    {% if has_change_permission %}
+        <li>
+            {% url opts|admin_urlname:'changelist' as changelist_url %}
+            <a href="{% add_preserved_filters changelist_url %}">{{ opts.verbose_name_plural|capfirst }}</a>
+        </li>
+        <li>
+            {% url opts|admin_urlname:'change' object.pk|admin_urlquote as object_url %}
+            <a href="{% add_preserved_filters object_url %}">{{ object|truncatewords:"18" }}</a>
+        </li>
+        <li>
+            {% url opts|admin_urlname:'permissions' object.pk|admin_urlquote as permissions_url %}
+            <a href="{% add_preserved_filters permissions_url %}">{% trans "Object permissions" %}</a>
+        </li>
+    {% else %}
+        <li>{{ opts.verbose_name_plural|capfirst }}</li>
+        <li>{{ original|truncatewords:"18" }}</li>
+        <li>{% trans "Object permissions" %}</li>
+    {% endif %}
     <li>{% trans "Manage user" %}: {{ user_obj|truncatewords:"18" }}</li>
 </ul>
 {% endif %}{% endblock %}
-
 
 {% block content %}
 <form action="." method="post">


### PR DESCRIPTION
…Grappelli 2.8 standards, including proper URLs and support for preserved_filters. Removed the duplicated field.errors in the field.html template file.