### PR TITLE
Improve performance of get_objects_for_user

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -552,7 +552,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
             group_fields = generic_fields
         else:
             group_fields = direct_fields
-        if not any_perm and len(codenames) and not has_global_perms:
+        if not any_perm and len(codenames) > 1 and not has_global_perms:
             user_obj_perms = user_obj_perms_queryset.values_list(*user_fields)
             groups_obj_perms = groups_obj_perms_queryset.values_list(*group_fields)
             data = list(user_obj_perms) + list(groups_obj_perms)
@@ -575,12 +575,12 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
 
     values = user_obj_perms_queryset.values_list(user_fields[0], flat=True)
     if user_model.objects.is_generic():
-        values = list(values)
+        values = set(values)
     q = Q(pk__in=values)
     if use_groups:
         values = groups_obj_perms_queryset.values_list(group_fields[0], flat=True)
         if group_model.objects.is_generic():
-            values = list(values)
+            values = set(values)
         q |= Q(pk__in=values)
 
     return queryset.filter(q)


### PR DESCRIPTION
Make sure get_objects_for_user with default option (use_groups=True and
any_perm=False) benefit from direct foreign keys and do not retrive the
full list in Python.

Also use set() instead of list(), as it's fastest to let Python does
deduplicating rather than database.

I've huge performance benefits with this change. Our application is using django-rest-framwork with [DjangoObjectPermissionsFilter](http://www.django-rest-framework.org/api-guide/filtering/#djangoobjectpermissionsfilter). Our user has access to ~5000 objects though group. Due to the way our group are built, user belong to 2 groups and each group as access to the same ~5000 objects

With a PostgreSQL database (on localhost), I've the following time to show one object:

Test | Average time per get
-------|---------
Using generic FK | 220 ms
Using direct FK   | 260 ms ! (a bit strange :))
With this PR and generic FK |  200 ms
With this PR and direct FK | 46 ms

