### PR TITLE
Reduce memory usage of clean_orphan_obj_perms

### DIFF
--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -128,8 +128,8 @@ def clean_orphan_obj_perms():
 
     deleted = 0
     # TODO: optimise
-    for perm in chain(UserObjectPermission.objects.all(),
-                      GroupObjectPermission.objects.all()):
+    for perm in chain(UserObjectPermission.objects.all().iterator(),
+                      GroupObjectPermission.objects.all().iterator()):
         if perm.content_object is None:
             logger.debug("Removing %s (pk=%d)" % (perm, perm.pk))
             perm.delete()


### PR DESCRIPTION
We use generic FK for your permission and don't yet (shame on us :)) delete permission object when object is deleted.

Therefor we use from time to time clean_orphan_obj_perms... but it iterate over *ALL* permission objects, and we have quiet a lots of them (about 100k)... this cause clean_orphan_obj_perms to cache all objects and consume way to much memory (multiple Gb).

This is a known issue of Django with a known solution: use [iterator](https://docs.djangoproject.com/en/1.10/ref/models/querysets/#iterator).

This PR use iterator() for clean_orphan_obj_perms when iterating over all permission objects. 