### PR TITLE
Fix group permission example

### DIFF
--- a/docs/userguide/assign.rst
+++ b/docs/userguide/assign.rst
@@ -128,9 +128,10 @@ Another example:
     >>> userA.has_perm('change_company', companyB)
     False
     >>> userB = User.objects.create(username="User B")
+    >>> userB.groups.add(companyUserGroupB)
     >>> userB.has_perm('change_company', companyA)
     False
-    >>> userA.has_perm('change_company', companyB)
+    >>> userB.has_perm('change_company', companyB)
     True
 
 Assigning Permissions inside Signals


### PR DESCRIPTION
In the documentation I found a little error in one of the [example](https://django-guardian.readthedocs.io/en/stable/userguide/assign.html#for-group). It was introduced with #292.