### PR TITLE
Added a optional checker variable to get_obj_perms

### DIFF
--- a/guardian/testapp/tests/test_tags.py
+++ b/guardian/testapp/tests/test_tags.py
@@ -6,6 +6,7 @@ from django.template import Template, Context, TemplateSyntaxError
 from django.test import TestCase
 
 from guardian.compat import get_user_model, template_debug_getter, template_debug_setter
+from guardian.core import ObjectPermissionChecker
 from guardian.exceptions import NotUserNorGroup
 from guardian.models import UserObjectPermission, GroupObjectPermission
 
@@ -128,6 +129,23 @@ class GetObjPermsTagTest(TestCase):
             '{{ obj_perms|join:" " }}',
         ))
         context = {'group': self.group, 'contenttype': self.ctype}
+        output = render(template, context)
+
+        self.assertEqual(output, 'delete_contenttype')
+        
+    def test_checker(self):
+        GroupObjectPermission.objects.assign_perm("delete_contenttype", self.group,
+                                                          self.ctype)
+
+        checker = ObjectPermissionChecker(self.user)
+        checker.prefetch_perms(Group.objects.all())
+                
+        template = ''.join((
+            '{% load guardian_tags %}',
+            '{% get_obj_perms group for contenttype as "obj_perms" checker %}',
+            '{{ obj_perms|join:" " }}',
+        ))
+        context = {'group': self.group, 'contenttype': self.ctype, 'checker': checker}
         output = render(template, context)
 
         self.assertEqual(output, 'delete_contenttype')


### PR DESCRIPTION
While reading through the documentation I stumbled over `ObjectPermissionChecker.prefetch_perms` which is pretty handy if working in `DetailViews`or  `ListViews` and larger querysets. These modifications work pretty well for me if I instantiate the ObjectPermissionChecker in a view (`ObjectPermissionChecker.prefetch_perms(queryset)`) and then passing the checker instance via the view's context to the template. This saves some queries compared to the current code that doesn't facilitate `prefetch_perms` in https://github.com/django-guardian/django-guardian/blob/devel/guardian/templatetags/guardian_tags.py#L45.

This is just a rough idea with basic testing because I'm not quite sure if I've misunderstood something or if I've overlooked an existing feature or workaround that achieves the same. So feel free to delete this pull request if it makes no sense to you. By the way, thank you for this library, really enjoying it!