### PR TITLE
Added on_delete to all ForeignKeys

### DIFF
--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -8,11 +8,11 @@ class TestModel(models.Model):
 
 
 class DirectUser(UserObjectPermissionBase):
-    content_object = models.ForeignKey('TestDirectModel')
+    content_object = models.ForeignKey('TestDirectModel', on_delete=models.CASCADE)
 
 
 class DirectGroup(GroupObjectPermissionBase):
-    content_object = models.ForeignKey('TestDirectModel')
+    content_object = models.ForeignKey('TestDirectModel', on_delete=models.CASCADE)
 
 
 class TestDirectModel(models.Model):

--- a/docs/userguide/assign.rst
+++ b/docs/userguide/assign.rst
@@ -16,7 +16,7 @@ Let's assume we have following model:
     class Task(models.Model):
         summary = models.CharField(max_length=32)
         content = models.TextField()
-        reported_by = models.ForeignKey(User)
+        reported_by = models.ForeignKey(User, on_delete=models.CASCADE)
         created_at = models.DateTimeField(auto_now_add=True)
 
 ... and we want to be able to set custom permission *view_task*. We let Django
@@ -28,7 +28,7 @@ model could look like:
     class Task(models.Model):
         summary = models.CharField(max_length=32)
         content = models.TextField()
-        reported_by = models.ForeignKey(User)
+        reported_by = models.ForeignKey(User, on_delete=models.CASCADE)
         created_at = models.DateTimeField(auto_now_add=True)
 
         class Meta:

--- a/docs/userguide/performance.rst
+++ b/docs/userguide/performance.rst
@@ -88,10 +88,10 @@ models:
         name = models.CharField(max_length=128, unique=True)
 
     class ProjectUserObjectPermission(UserObjectPermissionBase):
-        content_object = models.ForeignKey(Project)
+        content_object = models.ForeignKey(Project, on_delete=models.CASCADE)
 
     class ProjectGroupObjectPermission(GroupObjectPermissionBase):
-        content_object = models.ForeignKey(Project)
+        content_object = models.ForeignKey(Project, on_delete=models.CASCADE)
 
 
 .. important::

--- a/example_project/articles/models.py
+++ b/example_project/articles/models.py
@@ -27,8 +27,8 @@ class Article(models.Model):
 
 
 class ArticleUserObjectPermission(UserObjectPermissionBase):
-    content_object = models.ForeignKey(Article)
+    content_object = models.ForeignKey(Article, on_delete=models.CASCADE)
 
 
 class ArticleGroupObjectPermission(GroupObjectPermissionBase):
-    content_object = models.ForeignKey(Article)
+    content_object = models.ForeignKey(Article, on_delete=models.CASCADE)


### PR DESCRIPTION
`on_delete` is a [required argument beginning with Django 2.0](https://docs.djangoproject.com/en/1.10/ref/models/fields/#foreignkey) (the current master).  Among others this causes the tests against Django's master to fail.

This PR is not enough to fix the tests against Django's master, but it's a start.