### PR TITLE
Custom User Group model support

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -27,11 +27,11 @@ from benchmarks import settings
 from guardian.shortcuts import assign_perm
 from django.core.exceptions import ImproperlyConfigured
 from utils import show_settings
-from django.contrib.auth.models import User, Group
+from django.contrib.auth.models import User
 from django.utils.termcolors import colorize
 from benchmarks.models import TestModel
 from benchmarks.models import TestDirectModel
-from guardian.models import UserObjectPermission
+from guardian.models import UserObjectPermission, Group
 from django.contrib.contenttypes.models import ContentType
 
 USERS_COUNT = 50

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -34,7 +34,6 @@ __all__ = [
 # to get_user_model deferred to execution time
 
 user_model_label = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
-
 try:
     from django.contrib.auth import get_user_model
 except ImportError:

--- a/guardian/conf/settings.py
+++ b/guardian/conf/settings.py
@@ -24,6 +24,8 @@ GET_INIT_ANONYMOUS_USER = getattr(settings, 'GUARDIAN_GET_INIT_ANONYMOUS_USER',
 MONKEY_PATCH = getattr(settings, 'GUARDIAN_MONKEY_PATCH', True)
 
 GET_CONTENT_TYPE = getattr(settings, 'GUARDIAN_GET_CONTENT_TYPE', 'guardian.ctypes.get_default_content_type')
+GROUP_MODEL = getattr(settings, 'GUARDIAN_USER_GROUP_MODEL', 'django.contrib.auth.models.Group')
+
 
 
 def check_configuration():

--- a/guardian/models.py
+++ b/guardian/models.py
@@ -1,18 +1,21 @@
 from __future__ import unicode_literals
-from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from guardian.compat import unicode, user_model_label
+from guardian.compat import unicode, user_model_label, import_string
 from guardian.ctypes import get_content_type
 from guardian.managers import GroupObjectPermissionManager, UserObjectPermissionManager
+from guardian.conf import settings as guardian_settings
 
 try:
     from django.contrib.contenttypes.fields import GenericForeignKey
 except ImportError:
     from django.contrib.contenttypes.generic import GenericForeignKey
 
+
+Group = import_string(guardian_settings.GROUP_MODEL)
 
 class BaseObjectPermission(models.Model):
     """

--- a/guardian/models.py
+++ b/guardian/models.py
@@ -4,10 +4,9 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from guardian.compat import unicode, user_model_label, import_string
+from guardian.compat import unicode, user_model_label
 from guardian.ctypes import get_content_type
 from guardian.managers import GroupObjectPermissionManager, UserObjectPermissionManager
-from guardian.conf import settings as guardian_settings
 from guardian.utils import Group
 
 try:

--- a/guardian/models.py
+++ b/guardian/models.py
@@ -8,14 +8,13 @@ from guardian.compat import unicode, user_model_label, import_string
 from guardian.ctypes import get_content_type
 from guardian.managers import GroupObjectPermissionManager, UserObjectPermissionManager
 from guardian.conf import settings as guardian_settings
+from guardian.utils import Group
 
 try:
     from django.contrib.contenttypes.fields import GenericForeignKey
 except ImportError:
     from django.contrib.contenttypes.generic import GenericForeignKey
 
-
-Group = import_string(guardian_settings.GROUP_MODEL)
 
 class BaseObjectPermission(models.Model):
     """

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from itertools import groupby
 
 from django.apps import apps
-from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, Q, QuerySet
 from django.shortcuts import _get_queryset
@@ -17,7 +17,7 @@ from guardian.compat import basestring, get_user_model, is_anonymous
 from guardian.core import ObjectPermissionChecker
 from guardian.ctypes import get_content_type
 from guardian.exceptions import MixedContentTypeError, WrongAppError
-from guardian.models import GroupObjectPermission
+from guardian.models import GroupObjectPermission, Group
 from guardian.utils import get_anonymous_user, get_group_obj_perms_model, get_identity, get_user_obj_perms_model
 
 

--- a/guardian/templatetags/guardian_tags.py
+++ b/guardian/templatetags/guardian_tags.py
@@ -8,11 +8,12 @@
 from __future__ import unicode_literals
 
 from django import template
-from django.contrib.auth.models import AnonymousUser, Group
+from django.contrib.auth.models import AnonymousUser
 
 from guardian.compat import get_user_model
 from guardian.core import ObjectPermissionChecker
 from guardian.exceptions import NotUserNorGroup
+from guardian.models import Group
 
 register = template.Library()
 

--- a/guardian/testapp/tests/conf.py
+++ b/guardian/testapp/tests/conf.py
@@ -27,7 +27,7 @@ class TestDataMixin(object):
 
     def setUp(self):
         super(TestDataMixin, self).setUp()
-        from django.contrib.auth.models import Group
+        from guardian.models import Group
         try:
             from django.contrib.auth import get_user_model
             User = get_user_model()

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -9,14 +9,14 @@ try:
     auth_app = django_apps.get_app_config("auth")
 except ImportError:
     from django.contrib.auth import models as auth_app
-from django.contrib.auth.models import Group, Permission, AnonymousUser
+from django.contrib.auth.models import Permission, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from guardian.core import ObjectPermissionChecker
 from guardian.compat import get_user_model, create_permissions
 from guardian.exceptions import NotUserNorGroup
-from guardian.models import UserObjectPermission, GroupObjectPermission
+from guardian.models import Group, UserObjectPermission, GroupObjectPermission
 from guardian.shortcuts import assign_perm
 from guardian.management import create_anonymous_user
 

--- a/guardian/testapp/tests/test_decorators.py
+++ b/guardian/testapp/tests/test_decorators.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from django.conf import settings, global_settings
-from django.contrib.auth.models import Group, AnonymousUser
+from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db.models.base import ModelBase
 from django.http import HttpRequest
@@ -14,6 +14,7 @@ from django.test import TestCase
 
 from guardian.compat import get_user_model
 from guardian.compat import get_user_model_path
+from guardian.models import Group
 from guardian.compat import get_user_permission_full_codename
 import mock
 from guardian.decorators import permission_required, permission_required_or_403, permission_required_or_404

--- a/guardian/testapp/tests/test_direct_rel.py
+++ b/guardian/testapp/tests/test_direct_rel.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import Permission
 from django.test import TestCase
 
 from guardian.compat import get_user_model
@@ -15,6 +15,7 @@ from guardian.testapp.models import Project
 from guardian.testapp.models import ProjectGroupObjectPermission
 from guardian.testapp.models import ProjectUserObjectPermission
 from guardian.testapp.tests.conf import skipUnlessTestApp
+from guardian.models import Group 
 
 User = get_user_model()
 

--- a/guardian/testapp/tests/test_other.py
+++ b/guardian/testapp/tests/test_other.py
@@ -4,7 +4,6 @@ import mock
 import unittest
 
 from django.contrib.auth.models import AnonymousUser
-from django.contrib.auth.models import Group
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
@@ -23,6 +22,7 @@ from guardian.exceptions import ObjectNotPersisted
 from guardian.exceptions import WrongAppError
 from guardian.models import GroupObjectPermission
 from guardian.models import UserObjectPermission
+from guardian.models import Group
 from guardian.testapp.tests.conf import TestDataMixin
 User = get_user_model()
 user_model_path = get_user_model_path()

--- a/guardian/testapp/tests/test_tags.py
+++ b/guardian/testapp/tests/test_tags.py
@@ -1,13 +1,13 @@
 from __future__ import unicode_literals
 
-from django.contrib.auth.models import Group, AnonymousUser
+from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.template import Template, Context, TemplateSyntaxError
 from django.test import TestCase
 
 from guardian.compat import get_user_model, template_debug_getter, template_debug_setter
 from guardian.exceptions import NotUserNorGroup
-from guardian.models import UserObjectPermission, GroupObjectPermission
+from guardian.models import Group, UserObjectPermission, GroupObjectPermission
 
 User = get_user_model()
 

--- a/guardian/testapp/tests/test_utils.py
+++ b/guardian/testapp/tests/test_utils.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from django.test import TestCase
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.auth.models import Group, AnonymousUser
+from django.contrib.auth.models import AnonymousUser
 from django.db import models
 
 from guardian.compat import get_user_model
@@ -13,6 +13,7 @@ from guardian.testapp.models import ProjectGroupObjectPermission
 from guardian.models import UserObjectPermission
 from guardian.models import UserObjectPermissionBase
 from guardian.models import GroupObjectPermission
+from guardian.models import Group
 from guardian.utils import get_anonymous_user
 from guardian.utils import get_identity
 from guardian.utils import get_user_obj_perms_model

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -18,7 +18,6 @@ from guardian.compat import get_user_model, remote_model, import_string
 from guardian.conf import settings as guardian_settings
 from guardian.ctypes import get_content_type
 from guardian.exceptions import NotUserNorGroup
-#from guardian.models import Group 
 from itertools import chain
 
 import django

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -8,7 +8,7 @@ they actual input parameters/output type may change in future releases.
 from __future__ import unicode_literals
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth.models import AnonymousUser, Group
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db.models import Model
 from django.http import HttpResponseForbidden, HttpResponseNotFound
@@ -18,7 +18,7 @@ from guardian.compat import get_user_model, remote_model
 from guardian.conf import settings as guardian_settings
 from guardian.ctypes import get_content_type
 from guardian.exceptions import NotUserNorGroup
-from guardian.models import Group 
+#from guardian.models import Group 
 from itertools import chain
 
 import django

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -8,7 +8,7 @@ they actual input parameters/output type may change in future releases.
 from __future__ import unicode_literals
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.contrib.auth.models import AnonymousUser, Group
+from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db.models import Model
 from django.http import HttpResponseForbidden, HttpResponseNotFound
@@ -18,6 +18,7 @@ from guardian.compat import get_user_model, remote_model
 from guardian.conf import settings as guardian_settings
 from guardian.ctypes import get_content_type
 from guardian.exceptions import NotUserNorGroup
+from guardian.models import Group 
 from itertools import chain
 
 import django

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -8,13 +8,13 @@ they actual input parameters/output type may change in future releases.
 from __future__ import unicode_literals
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.contrib.auth.models import AnonymousUser, Group
+from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db.models import Model
 from django.http import HttpResponseForbidden, HttpResponseNotFound
 from django.shortcuts import render_to_response
 from django.template import RequestContext
-from guardian.compat import get_user_model, remote_model
+from guardian.compat import get_user_model, remote_model, import_string
 from guardian.conf import settings as guardian_settings
 from guardian.ctypes import get_content_type
 from guardian.exceptions import NotUserNorGroup
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 abspath = lambda *p: os.path.abspath(os.path.join(*p))
 
 
+Group = import_string(guardian_settings.GROUP_MODEL)
 def get_anonymous_user():
     """
     Returns ``User`` instance (not ``AnonymousUser``) depending on


### PR DESCRIPTION
We added support for custom user group models. (In our case, we use a custom group model for permission inheritance) 

a new config setting: `GUARDIAN_CUSTOM_USER_GROUP` will load the custom user group module. Similar to a custom User Model, a custom User Group must have all the relationships as Django's built in group