### PR TITLE
Fix django admin 1.11 not showing selected permissions

### DIFF
--- a/guardian/forms.py
+++ b/guardian/forms.py
@@ -31,7 +31,7 @@ class BaseObjectPermissionsForm(forms.Form):
         field = field_class(
             label=self.get_obj_perms_field_label(),
             choices=self.get_obj_perms_field_choices(),
-            initial=self.get_obj_perms_field_initial(),
+            initial=list(self.get_obj_perms_field_initial()),
             widget=self.get_obj_perms_field_widget(),
             required=self.are_obj_perms_required(),
         )

--- a/guardian/testapp/tests/test_admin.py
+++ b/guardian/testapp/tests/test_admin.py
@@ -162,7 +162,7 @@ class AdminTests(TestCase):
         response = self.client.post(url, data, follow=True)
         self.assertEqual(len(response.redirect_chain), 1)
         self.assertEqual(response.redirect_chain[0][1], 302)
-
+        self.assertIn('selected', str(response.context['form']))
         self.assertEqual(
             set(get_perms(self.user, self.obj)),
             set(perms),


### PR DESCRIPTION
Fixes https://github.com/django-guardian/django-guardian/issues/510. This was caused by queryset not being supported as field values.

Line 589 of forms/widgets.py in django 1.11 was failing.
```
selected = (
                    force_text(subvalue) in value and
                    (has_selected is False or self.allow_multiple_selected)
                )
```

I added a fix and a failing test previously