### PR TITLE
Replaced syncdb with makemigrations + migrate

### DIFF
--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -107,7 +107,8 @@ class Benchmark(object):
 
     def prepare_db(self):
         from django.core.management import call_command
-        call_command('syncdb', interactive=False)
+        call_command('makemigrations', interactive=False)
+        call_command('migrate', interactive=False)
 
         for model in [User, Group, self.Model]:
             model.objects.all().delete()

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -21,7 +21,7 @@ and hook guardian's authentication backend::
 
 .. note::
    Once project is configured to work with ``django-guardian``, calling
-   ``syncdb`` management command would create ``User`` instance for
+   ``migrate`` management command would create ``User`` instance for
    anonymous user support (with name of ``AnonymousUser``).
 
 .. note::
@@ -127,7 +127,7 @@ GUARDIAN_GET_INIT_ANONYMOUS_USER
 Guardian supports object level permissions for anonymous users, however when
 in our project we use custom User model, default function might fail. This can
 lead to issues as ``guardian`` tries to create anonymous user after each
-``syncdb`` call. Object that is going to be created is retrieved using function
+``migrate`` call. Object that is going to be created is retrieved using function
 pointed by this setting. Once retrieved, ``save`` method would be called on
 that instance.
 

--- a/docs/userguide/assign.rst
+++ b/docs/userguide/assign.rst
@@ -36,9 +36,8 @@ model could look like:
                 ('view_task', 'View task'),
             )
 
-After we call ``syncdb`` (with a ``--all`` switch if you are using south)
-management command our *view_task* permission would be added to default set of
-permissions.
+After we call management commands ``makemigrations`` and ``migrate``
+our *view_task* permission would be added to default set of permissions.
 
 .. note::
    By default, Django adds 3 permissions for each registered model:


### PR DESCRIPTION
`makemigrations` + `migrate` replaced `syncdb` in Django 1.7, which is no longer supported.
https://docs.djangoproject.com/en/1.7/topics/migrations/