### PR TITLE
Filter attached perms by ctype in get_groups_with_perms

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -338,7 +338,7 @@ def get_groups_with_perms(obj, attach_perms=False):
         groups_with_perms = get_groups_with_perms(obj)
         qs = group_model.objects.filter(group__in=groups_with_perms).prefetch_related('group', 'permission')
         if group_model is GroupObjectPermission:
-            qs = qs.filter(object_pk=obj.pk)
+            qs = qs.filter(object_pk=obj.pk, content_type=ctype)
         else:
             qs = qs.filter(content_object_id=obj.pk)
 

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -482,6 +482,18 @@ class GetGroupsWithPerms(TestCase):
         result = get_groups_with_perms(self.obj1, attach_perms=True)
         self.assertEqual(len(result), 0)
 
+    def test_filter_by_contenttype(self):
+        # Make sure that both objects have same pk.
+        obj = ContentType.objects.create(pk=1042, model='baz', app_label='guardian-tests')
+        group = Group.objects.create(pk=1042, name='group')
+
+        assign_perm("change_group", self.group1, group)
+        assign_perm("change_contenttype", self.group1, obj)
+
+        result = get_groups_with_perms(obj, attach_perms=True)
+        # No group permissions should be included, even though objects have same pk.
+        self.assertEqual(result[self.group1], ["change_contenttype"])
+
     def test_mixed(self):
         assign_perm("change_contenttype", self.group1, self.obj1)
         assign_perm("change_contenttype", self.group1, self.obj2)


### PR DESCRIPTION
``get_groups_with_perms`` called with ``attach_perms=True`` doesn't filter permissions by content type, so permissions for all objects with the same ``pk`` are returned instead of just permissions for given object.