### PR TITLE
Optional direct foreign key model

### DIFF
--- a/docs/userguide/performance.rst
+++ b/docs/userguide/performance.rst
@@ -105,6 +105,11 @@ also possible to use only user or only group-based direct relation, however it
 is discouraged (it's not consistent and might be a quick road to hell from the
 maintainence point of view, especially).
 
+To temporarily disable the detection of this direct relation model, add
+``enabled = False`` to the object permission model classes. This is useful to
+allow the ORM to create the tables for you and for you to migrate data from the
+generic model table before using the direct models.
+
 .. note::
    By defining direct relation models we can also tweak that object permission
    model, i.e. by adding some fields.

--- a/docs/userguide/performance.rst
+++ b/docs/userguide/performance.rst
@@ -108,7 +108,7 @@ maintainence point of view, especially).
 To temporarily disable the detection of this direct relation model, add
 ``enabled = False`` to the object permission model classes. This is useful to
 allow the ORM to create the tables for you and for you to migrate data from the
-generic model table before using the direct models.
+generic model tables before using the direct models.
 
 .. note::
    By defining direct relation models we can also tweak that object permission

--- a/guardian/__init__.py
+++ b/guardian/__init__.py
@@ -7,7 +7,7 @@ from . import checks
 default_app_config = 'guardian.apps.GuardianConfig'
 
 # PEP 396: The __version__ attribute's value SHOULD be a string.
-__version__ = '1.4.9'
+__version__ = '1.5.0'
 
 # Compatibility to eg. django-rest-framework
 VERSION = tuple(int(x) for x in __version__.split('.')[:3])

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -176,7 +176,7 @@ def get_obj_perms_model(obj, base_cls, generic_cls):
         else:
             model = getattr(attr, 'related_model', None)
         if (model and issubclass(model, base_cls) and
-                model is not generic_cls and getattr(attr, 'enabled', True)):
+                model is not generic_cls and getattr(model, 'enabled', True)):
             # if model is generic one it would be returned anyway
             if not model.objects.is_generic():
                 # make sure that content_object's content_type is same as

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -176,7 +176,7 @@ def get_obj_perms_model(obj, base_cls, generic_cls):
         else:
             model = getattr(attr, 'related_model', None)
         if (model and issubclass(model, base_cls) and
-                model is not generic_cls):
+                model is not generic_cls and getattr(attr, 'enabled', True)):
             # if model is generic one it would be returned anyway
             if not model.objects.is_generic():
                 # make sure that content_object's content_type is same as


### PR DESCRIPTION
This PR adds an optional `enabled` toggle on direct foreign key models that allows you to disable their automatic detection. This is useful so that you can allow the ORM to create the tables and  migrate the data from the generic model tables before using the direct models.