### PR TITLE
Fix for issue #543

### DIFF
--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -82,7 +82,7 @@ class ObjectPermissionBackend(object):
             return False
 
         if '.' in perm:
-            app_label, perm = perm.split('.')
+            app_label, _ = perm.split('.', maxsplit=1)
             if app_label != obj._meta.app_label:
                 # Check the content_type app_label when permission
                 # and obj app labels don't match.

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -71,7 +71,8 @@ class ObjectPermissionChecker(object):
             return False
         elif self.user and self.user.is_superuser:
             return True
-        perm = perm.split('.')[-1]
+        if '.' in perm:
+            _, perm = perm.split('.', maxsplit=1)
         return perm in self.get_perms(obj)
 
     def get_group_filters(self, obj):


### PR DESCRIPTION
Guardian's Backend will no longer crash on permission strings with more than one '.'; instead it will deny permission as django.contrib.auth does.