### PR TITLE
Fallback to Model Permissions (Core)

### DIFF
--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -144,10 +144,21 @@ def remote_field(field):
     return field.remote_field
 
 
-def remote_model(field):
+def get_remote_model(field):
     if django.VERSION < (1, 9):
         return remote_field(field).to
     return remote_field(field).model
+
+def get_related_model(field):
+    if django.VERSION < (1, 8):
+        return getattr(field, 'field_model', None)
+    return getattr(field, 'related_model', None)
+
+def get_model_fields (model):
+    if django.VERSION >= (1, 8):
+        return (f for f in model._meta.get_fields()
+            if (f.one_to_many or f.one_to_one) and f.auto_created)
+    return model._meta.get_all_related_objects()
 
 
 # Django 1.10 compatibility

--- a/guardian/conf/settings.py
+++ b/guardian/conf/settings.py
@@ -26,6 +26,16 @@ MONKEY_PATCH = getattr(settings, 'GUARDIAN_MONKEY_PATCH', True)
 GET_CONTENT_TYPE = getattr(settings, 'GUARDIAN_GET_CONTENT_TYPE', 'guardian.ctypes.get_default_content_type')
 
 
+FALLBACK_TO_MODEL = getattr(settings, 'GUARDIAN_FALLBACK_TO_MODEL', None)
+
+def effective_fallback(input_fallback):
+    if input_fallback is not None:
+        return input_fallback
+    if FALLBACK_TO_MODEL is not None:
+        return FALLBACK_TO_MODEL
+    return False
+
+
 def check_configuration():
     if RENDER_403 and RAISE_403:
         raise ImproperlyConfigured("Cannot use both GUARDIAN_RENDER_403 AND "

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import Permission
 from django.db.models.query import QuerySet
 from django.utils.encoding import force_text
 from guardian.compat import get_user_model
+from guardian.conf.settings import effective_fallback
 from guardian.ctypes import get_content_type
 from guardian.utils import get_group_obj_perms_model, get_identity, get_user_obj_perms_model
 from itertools import chain
@@ -58,7 +59,7 @@ class ObjectPermissionChecker(object):
         self.user, self.group = get_identity(user_or_group)
         self._obj_perms_cache = {}
 
-    def has_perm(self, perm, obj):
+    def has_perm(self, perm, obj, fallback_to_model=None):
         """
         Checks if user/group has given permission for object.
 
@@ -72,7 +73,7 @@ class ObjectPermissionChecker(object):
         elif self.user and self.user.is_superuser:
             return True
         perm = perm.split('.')[-1]
-        return perm in self.get_perms(obj)
+        return perm in self.get_perms(obj, fallback_to_model=None)
 
     def get_group_filters(self, obj):
         User = get_user_model()
@@ -88,6 +89,7 @@ class ObjectPermissionChecker(object):
             group_filters = {fieldname: self.user}
         else:
             group_filters = {'%s__group' % group_rel_name: self.group}
+
         if group_model.objects.is_generic():
             group_filters.update({
                 '%s__content_type' % group_rel_name: ctype,
@@ -98,13 +100,14 @@ class ObjectPermissionChecker(object):
 
         return group_filters
 
+
     def get_user_filters(self, obj):
         ctype = get_content_type(obj)
-        model = get_user_obj_perms_model(obj)
-        related_name = model.permission.field.related_query_name()
+        perms_model = get_user_obj_perms_model(obj) # ex. UserObjectPermission
+        related_name = perms_model.permission.field.related_query_name() # ex. userobjectpermission
 
         user_filters = {'%s__user' % related_name: self.user}
-        if model.objects.is_generic():
+        if perms_model.objects.is_generic():
             user_filters.update({
                 '%s__content_type' % related_name: ctype,
                 '%s__object_pk' % related_name: obj.pk,
@@ -114,27 +117,69 @@ class ObjectPermissionChecker(object):
 
         return user_filters
 
-    def get_user_perms(self, obj):
+    def get_user_perms(self, obj, fallback_to_model=None):
         ctype = get_content_type(obj)
 
-        perms_qs = Permission.objects.filter(content_type=ctype)
-        user_filters = self.get_user_filters(obj)
-        user_perms_qs = perms_qs.filter(**user_filters)
-        user_perms = user_perms_qs.values_list("codename", flat=True)
+        obj_perms = Permission.objects.filter(content_type=ctype) \
+                .filter(**self.get_user_filters(obj)) \
+                .values_list("codename", flat=True)
 
-        return user_perms
+        # add missing from user's model level perms
+        if effective_fallback(fallback_to_model):
+            return set(list(obj_perms)) \
+                .union(set(list(self.get_user_model_perms(obj))))
 
-    def get_group_perms(self, obj):
+        return obj_perms
+
+    def get_user_model_perms(self, obj):
+        """
+        self.user's model level permissions for the obj's content type
+        hits db
+        """
+        ctype = get_content_type(obj)
+        return self.user.user_permissions.filter(content_type=ctype) \
+            .values_list("codename", flat=True)
+
+    def get_group_perms(self, obj, fallback_to_model=None):
         ctype = get_content_type(obj)
 
-        perms_qs = Permission.objects.filter(content_type=ctype)
-        group_filters = self.get_group_filters(obj)
-        group_perms_qs = perms_qs.filter(**group_filters)
-        group_perms = group_perms_qs.values_list("codename", flat=True)
+        obj_perms = Permission.objects.filter(content_type=ctype) \
+                .filter(**self.get_group_filters(obj)) \
+                .values_list("codename", flat=True)
 
-        return group_perms
+        # add missing from user's groups' model level perms
+        if effective_fallback(fallback_to_model):
+            if self.user:
+                return set(list(obj_perms))\
+                    .union(set(list(self.get_user_groups_model_perms(obj))))
+            # self.group
+            return set(list(obj_perms))\
+                .union(set(list(self.get_group_model_perms(obj))))
 
-    def get_perms(self, obj):
+        return obj_perms
+
+    def get_user_groups_model_perms(self, obj):
+        """
+        self.user's groups' model level permissions for the obj's content type
+        hits db
+        """
+        ctype = get_content_type(obj)
+        user_groups_field = self.user._meta.get_field('groups')
+        user_groups_query = 'group__%s' % user_groups_field.related_query_name()
+        return Permission.objects \
+            .filter(content_type=ctype, **{user_groups_query: self.user}) \
+            .values_list("codename", flat=True)
+
+    def get_group_model_perms(self, obj):
+        """
+        self.group's model level permissions for the obj's content type
+        hits db
+        """
+        ctype = get_content_type(obj)
+        return self.group.permissions.filter(content_type=ctype) \
+            .values_list("codename", flat=True)
+
+    def get_perms(self, obj, fallback_to_model=None):
         """
         Returns list of ``codename``'s of all permissions for given ``obj``.
 
@@ -153,15 +198,18 @@ class ObjectPermissionChecker(object):
             elif self.user:
                 # Query user and group permissions separately and then combine
                 # the results to avoid a slow query
-                user_perms = self.get_user_perms(obj)
-                group_perms = self.get_group_perms(obj)
+                user_perms = self.get_user_perms(obj, fallback_to_model)
+                group_perms = self.get_group_perms(obj, fallback_to_model)
                 perms = list(set(chain(user_perms, group_perms)))
             else:
                 group_filters = self.get_group_filters(obj)
-                perms = list(set(chain(*Permission.objects
+                perms = set(chain(*Permission.objects
                                        .filter(content_type=ctype)
                                        .filter(**group_filters)
-                                       .values_list("codename"))))
+                                       .values_list("codename")))
+                if effective_fallback(fallback_to_model):
+                    perms = perms.union(set(self.get_group_model_perms(obj)))
+                perms=list(perms)
             self._obj_perms_cache[key] = perms
         return self._obj_perms_cache[key]
 

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -192,9 +192,9 @@ class ObjectPermissionChecker(object):
         key = self.get_local_cache_key(obj)
         if key not in self._obj_perms_cache:
             if self.user and self.user.is_superuser:
-                perms = list(chain(*Permission.objects
-                                   .filter(content_type=ctype)
-                                   .values_list("codename")))
+                perms = list(Permission.objects
+                           .filter(content_type=ctype)
+                           .values_list("codename", flat=True))
             elif self.user:
                 # Query user and group permissions separately and then combine
                 # the results to avoid a slow query
@@ -203,14 +203,15 @@ class ObjectPermissionChecker(object):
                 perms = list(set(chain(user_perms, group_perms)))
             else:
                 group_filters = self.get_group_filters(obj)
-                perms = set(chain(*Permission.objects
-                                       .filter(content_type=ctype)
-                                       .filter(**group_filters)
-                                       .values_list("codename")))
+                perms = set(Permission.objects
+                               .filter(content_type=ctype)
+                               .filter(**group_filters)
+                               .values_list("codename", flat=True))
                 if effective_fallback(fallback_to_model):
                     perms = perms.union(set(self.get_group_model_perms(obj)))
                 perms=list(perms)
             self._obj_perms_cache[key] = perms
+            return perms
         return self._obj_perms_cache[key]
 
     def get_local_cache_key(self, obj):

--- a/guardian/ctypes.py
+++ b/guardian/ctypes.py
@@ -6,11 +6,11 @@ from guardian.conf import settings as guardian_settings
 from guardian.compat import import_string
 
 
-def get_content_type(obj):
+def get_content_type(model):
     get_content_type_function = import_string(
         guardian_settings.GET_CONTENT_TYPE)
-    return get_content_type_function(obj)
+    return get_content_type_function(model)
 
 
-def get_default_content_type(obj):
-    return ContentType.objects.get_for_model(obj)
+def get_default_content_type(model):
+    return ContentType.objects.get_for_model(model)

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -217,7 +217,7 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
         # user permission for model
         perm = perm_objs.get(codename='change_project')
         self.user.user_permissions.add(perm)
-        user_checker._obj_perms_cache = {}
+        user_checker.clear_cache()
         # user check
         self.assertEqual(['add_project', 'change_project'],
                          sorted(user_checker.get_perms(foo_project, True)))
@@ -228,8 +228,8 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
         # group permission for model
         perm = perm_objs.get(codename='delete_project')
         self.group.permissions.add(perm)
-        user_checker._obj_perms_cache = {} # have to have both
-        group_checker._obj_perms_cache = {}
+        user_checker.clear_cache() # have to have both
+        group_checker.clear_cache()
         # user check
         self.assertEqual(['add_project', 'change_project', 'delete_project'],
                          sorted(user_checker.get_perms(foo_project, True)))

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -233,6 +233,8 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
         # user check
         self.assertEqual(['add_project', 'change_project', 'delete_project'],
                          sorted(user_checker.get_perms(foo_project, True)))
+        self.assertEqual(['add_project'],
+                         sorted(user_checker.get_perms(foo_project, False)))
         self.assertEqual(['change_project', 'delete_project'],
                          sorted(user_checker.get_perms(bar_project, True)))
         # group check

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django>=1.10.6
 six
 django-environ
 bumpversion
+mock


### PR DESCRIPTION
Related to #380, and #49.

This updates core.py and test_core.py to allow the following checker functions optionally fallback to (or include) model level permissions:

```
get_user_perms(self, obj, fallback_to_model=None)
get_group_perms(self, obj, fallback_to_model=None)
get_perms(self, obj, fallback_to_model=None)
```

Please note the fallback_to_model parameter. 

This also includes, a global setting two that end: `FALLBACK_TO_MODEL`. Function level takes precedence if both provided. Overall defaults to False in order not to change the default behavior. 

When get_perms is used with `fallback_to_model=True`, the combined permissions go through the existing caching mechanism, so a performance degradation is not expected (although not tested). 

Tests are implemented, but documentation is not. More is planned. 