### PR TITLE
Attaching _obj_perms_cache to user maintains it btw calls to user.has_perm()

### DIFF
--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -82,7 +82,7 @@ class ObjectPermissionBackend(object):
             return False
 
         expected_app_label = obj._meta.app_label
-        perm.replace(expected_app_label + '.', '')
+        perm = perm.replace(expected_app_label + '.', '')
 
         if '.' in perm and not settings.ALLOW_CROSS_MODEL_PERMISSIONS:
             app_label, perm = perm.split('.')

--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -83,7 +83,8 @@ class ObjectPermissionBackend(object):
 
         if '.' in perm:
             app_label, perm = perm.split('.')
-            if app_label != obj._meta.app_label:
+            if not settings.ALLOW_CROSS_MODEL_PERMISSIONS \
+                and app_label != obj._meta.app_label:
                 # Check the content_type app_label when permission
                 # and obj app labels don't match.
                 ctype = get_content_type(obj)

--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -81,18 +81,19 @@ class ObjectPermissionBackend(object):
         if not support:
             return False
 
-        if '.' in perm:
+        expected_app_label = obj._meta.app_label
+        perm.replace(expected_app_label + '.', '')
+
+        if '.' in perm and not settings.ALLOW_CROSS_MODEL_PERMISSIONS:
             app_label, perm = perm.split('.')
-            if not settings.ALLOW_CROSS_MODEL_PERMISSIONS \
-                and app_label != obj._meta.app_label:
-                # Check the content_type app_label when permission
-                # and obj app labels don't match.
-                ctype = get_content_type(obj)
-                if app_label != ctype.app_label:
-                    raise WrongAppError("Passed perm has app label of '%s' while "
-                                        "given obj has app label '%s' and given obj"
-                                        "content_type has app label '%s'" %
-                                        (app_label, obj._meta.app_label, ctype.app_label))
+            # Check the content_type app_label when permission
+            # and obj app labels don't match.
+            ctype = get_content_type(obj)
+            if app_label != ctype.app_label:
+                raise WrongAppError("Passed perm has app label of '%s' while "
+                                    "given obj has app label '%s' and given obj"
+                                    "content_type has app label '%s'" %
+                                    (app_label, obj._meta.app_label, ctype.app_label))
 
         check = ObjectPermissionChecker(user_obj)
         return check.has_perm(perm, obj)

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -144,10 +144,21 @@ def remote_field(field):
     return field.remote_field
 
 
-def remote_model(field):
+def get_remote_model(field):
     if django.VERSION < (1, 9):
         return remote_field(field).to
     return remote_field(field).model
+
+def get_related_model(field):
+    if django.VERSION < (1, 8):
+        return getattr(field, 'field_model', None)
+    return getattr(field, 'related_model', None)
+
+def get_model_fields (model):
+    if django.VERSION >= (1, 8):
+        return (f for f in model._meta.get_fields()
+            if (f.one_to_many or f.one_to_one) and f.auto_created)
+    return model._meta.get_all_related_objects()
 
 
 # Django 1.10 compatibility

--- a/guardian/conf/settings.py
+++ b/guardian/conf/settings.py
@@ -23,6 +23,8 @@ GET_INIT_ANONYMOUS_USER = getattr(settings, 'GUARDIAN_GET_INIT_ANONYMOUS_USER',
 
 MONKEY_PATCH = getattr(settings, 'GUARDIAN_MONKEY_PATCH', True)
 
+ALLOW_CROSS_MODEL_PERMISSIONS = getattr(settings, 'GUARDIAN_ALLOW_CROSS_MODEL_PERMISSIONS', False)
+
 GET_CONTENT_TYPE = getattr(settings, 'GUARDIAN_GET_CONTENT_TYPE', 'guardian.ctypes.get_default_content_type')
 
 

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -147,9 +147,9 @@ class ObjectPermissionChecker(object):
         key = self.get_local_cache_key(obj)
         if key not in self._obj_perms_cache:
             if self.user and self.user.is_superuser:
-                perms = list(chain(*Permission.objects
-                                   .filter(content_type=ctype)
-                                   .values_list("codename")))
+                perms = list(Permission.objects
+                           .filter(content_type=ctype)
+                           .values_list("codename", flat=True))
             elif self.user:
                 # Query user and group permissions separately and then combine
                 # the results to avoid a slow query
@@ -158,11 +158,12 @@ class ObjectPermissionChecker(object):
                 perms = list(set(chain(user_perms, group_perms)))
             else:
                 group_filters = self.get_group_filters(obj)
-                perms = list(set(chain(*Permission.objects
-                                       .filter(content_type=ctype)
-                                       .filter(**group_filters)
-                                       .values_list("codename"))))
+                perms = list(set(Permission.objects
+                               .filter(content_type=ctype)
+                               .filter(**group_filters)
+                               .values_list("codename", flat=True)))
             self._obj_perms_cache[key] = perms
+            return perms
         return self._obj_perms_cache[key]
 
     def get_local_cache_key(self, obj):

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -151,18 +151,15 @@ class ObjectPermissionChecker(object):
                 perms = list(Permission.objects
                            .filter(content_type=ctype)
                            .values_list("codename", flat=True))
-            elif self.user:
-                # Query user and group permissions separately and then combine
-                # the results to avoid a slow query
-                user_perms = self.get_user_perms(obj)
-                group_perms = self.get_group_perms(obj)
-                perms = list(set(chain(user_perms, group_perms)))
             else:
-                group_filters = self.get_group_filters(obj)
-                perms = list(set(Permission.objects
-                               .filter(content_type=ctype)
-                               .filter(**group_filters)
-                               .values_list("codename", flat=True)))
+                group_perms = self.get_group_perms(obj)
+                if self.user:
+                    # Query user and group permissions separately and then combine
+                    # the results to avoid a slow query
+                    user_perms = self.get_user_perms(obj)
+                    perms = list(set(chain(user_perms, group_perms)))
+                else:
+                    perms = list(set(group_perms))
             self._obj_perms_cache[key] = perms
             return perms
         return self._obj_perms_cache[key]

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -125,16 +125,16 @@ class ObjectPermissionChecker(object):
         if key not in self._obj_perms_cache:
             if self.user and self.user.is_superuser:
                 ctype = get_content_type(obj)
-                perms = set(self._filter_perms(obj, content_type=ctype))
+                perms = self._filter_perms(obj, content_type=ctype)
             else:
                 group_perms = self.get_group_perms(obj)
                 if self.user:
                     # Query user and group permissions separately and then combine
                     # the results to avoid a slow query
-                    user_perms = self.get_user_perms(obj)
-                    perms = set(chain(user_perms, group_perms))
+                    perms = self.get_user_perms(obj)
+                    perms.update(group_perms)
                 else:
-                    perms = set(group_perms)
+                    perms = group_perms
             self._obj_perms_cache[key] = perms
             return perms
         return self._obj_perms_cache[key]

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -147,16 +147,16 @@ class ObjectPermissionChecker(object):
         key = self.get_local_cache_key(obj)
         if key not in self._obj_perms_cache:
             if self.user and self.user.is_superuser:
-                perms = list(self.get_content_type_perms(obj))
+                perms = set(self.get_content_type_perms(obj))
             else:
                 group_perms = self.get_group_perms(obj)
                 if self.user:
                     # Query user and group permissions separately and then combine
                     # the results to avoid a slow query
                     user_perms = self.get_user_perms(obj)
-                    perms = list(set(chain(user_perms, group_perms)))
+                    perms = set(chain(user_perms, group_perms))
                 else:
-                    perms = list(set(group_perms))
+                    perms = set(group_perms)
             self._obj_perms_cache[key] = perms
             return perms
         return self._obj_perms_cache[key]

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -125,23 +125,15 @@ class ObjectPermissionChecker(object):
 
     def get_user_perms(self, obj):
         ctype = get_content_type(obj)
-
-        perms_qs = Permission.objects.filter(content_type=ctype)
-        user_filters = self.get_user_filters(obj)
-        user_perms_qs = perms_qs.filter(**user_filters)
-        user_perms = user_perms_qs.values_list("codename", flat=True)
-
-        return user_perms
+        return Permission.objects.filter(content_type=ctype) \
+                    .filter(**self.get_user_filters(obj)) \
+                    .values_list("codename", flat=True)
 
     def get_group_perms(self, obj):
         ctype = get_content_type(obj)
-
-        perms_qs = Permission.objects.filter(content_type=ctype)
-        group_filters = self.get_group_filters(obj)
-        group_perms_qs = perms_qs.filter(**group_filters)
-        group_perms = group_perms_qs.values_list("codename", flat=True)
-
-        return group_perms
+        return Permission.objects.filter(content_type=ctype) \
+                    .filter(**self.get_group_filters(obj)) \
+                    .values_list("codename", flat=True)
 
     def get_perms(self, obj):
         """

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -56,6 +56,15 @@ class ObjectPermissionChecker(object):
           ``Group`` instance
         """
         self.user, self.group = get_identity(user_or_group)
+        self.user_or_group = user_or_group
+
+        if not hasattr(user_or_group, '_obj_perms_cache'):
+            user_or_group._obj_perms_cache = {}
+            # attaching cache to user/group keeps it between successive calls to user.has_perm()
+        self._obj_perms_cache = user_or_group._obj_perms_cache
+
+    def clear_cache(self):
+        self.user_or_group._obj_perms_cache = {}
         self._obj_perms_cache = {}
 
     def has_perm(self, perm, obj):

--- a/guardian/ctypes.py
+++ b/guardian/ctypes.py
@@ -6,11 +6,11 @@ from guardian.conf import settings as guardian_settings
 from guardian.compat import import_string
 
 
-def get_content_type(obj):
+def get_content_type(model):
     get_content_type_function = import_string(
         guardian_settings.GET_CONTENT_TYPE)
-    return get_content_type_function(obj)
+    return get_content_type_function(model)
 
 
-def get_default_content_type(obj):
-    return ContentType.objects.get_for_model(obj)
+def get_default_content_type(model):
+    return ContentType.objects.get_for_model(model)

--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -9,6 +9,11 @@ from guardian.models import Permission
 import warnings
 
 
+def clear_cache(user_or_group):
+    user_or_group._obj_perms_cache = {}
+
+
+
 class BaseObjectPermissionManager(models.Manager):
 
     @property
@@ -31,6 +36,7 @@ class BaseObjectPermissionManager(models.Manager):
         Assigns permission with given ``perm`` for an instance ``obj`` and
         ``user``.
         """
+        clear_cache(user_or_group)
         if getattr(obj, 'pk', None) is None:
             raise ObjectNotPersisted("Object %s needs to be persisted first"
                                      % obj)
@@ -55,6 +61,7 @@ class BaseObjectPermissionManager(models.Manager):
         ``user_or_group``.
         """
 
+        clear_cache(user_or_group)
         ctype = get_content_type(queryset.model)
         if not isinstance(perm, Permission):
             permission = Permission.objects.get(content_type=ctype, codename=perm)
@@ -91,6 +98,7 @@ class BaseObjectPermissionManager(models.Manager):
         use ``Queryset.delete`` method for removing it. Main implication of this
         is that ``post_delete`` signals would NOT be fired.
         """
+        clear_cache(user_or_group)
         if getattr(obj, 'pk', None) is None:
             raise ObjectNotPersisted("Object %s needs to be persisted first"
                                      % obj)
@@ -117,6 +125,8 @@ class BaseObjectPermissionManager(models.Manager):
         use ``Queryset.delete`` method for removing it. Main implication of this
         is that ``post_delete`` signals would NOT be fired.
         """
+        clear_cache(user_or_group)
+
         filters = Q(**{self.user_or_group_field: user_or_group})
 
         if isinstance(perm, Permission):

--- a/guardian/models.py
+++ b/guardian/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
+from guardian.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.six import python_2_unicode_compatible
@@ -34,7 +35,8 @@ class BaseObjectPermission(models.Model):
 
     def save(self, *args, **kwargs):
         content_type = get_content_type(self.content_object)
-        if content_type != self.permission.content_type:
+        if not settings.ALLOW_CROSS_MODEL_PERMISSIONS \
+            and content_type != self.permission.content_type:
             raise ValidationError("Cannot persist permission not designed for "
                                   "this class (permission's type is %r and object's type is %r)"
                                   % (self.permission.content_type, content_type))

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -18,7 +18,9 @@ from guardian.core import ObjectPermissionChecker
 from guardian.ctypes import get_content_type
 from guardian.exceptions import MixedContentTypeError, WrongAppError
 from guardian.models import GroupObjectPermission
-from guardian.utils import get_anonymous_user, get_group_obj_perms_model, get_identity, get_user_obj_perms_model
+from guardian.managers import clear_cache
+from guardian.utils import get_anonymous_user, get_group_obj_perms_model, \
+    get_identity, get_user_obj_perms_model
 
 
 def assign_perm(perm, user_or_group, obj=None):
@@ -71,6 +73,7 @@ def assign_perm(perm, user_or_group, obj=None):
     """
 
     user, group = get_identity(user_or_group)
+    clear_cache(user_or_group)
     # If obj is None we try to operate on global permissions
     if obj is None:
         if not isinstance(perm, Permission):
@@ -135,6 +138,7 @@ def remove_perm(perm, user_or_group=None, obj=None):
 
     """
     user, group = get_identity(user_or_group)
+    clear_cache(user_or_group)
     if obj is None:
         try:
             app_label, codename = perm.split('.', 1)

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -289,9 +289,12 @@ def get_users_with_perms(obj, attach_perms=False, with_superusers=False,
                                          with_superusers=with_superusers):
             # TODO: Support the case of set with_group_users but not with_superusers.
             if with_group_users or with_superusers:
-                users[user] = sorted(get_perms(user, obj))
+                perms = get_perms(user, obj)
             else:
-                users[user] = sorted(get_user_perms(user, obj))
+                perms = get_user_perms(user, obj)
+            app_label = obj._meta.app_label + '.'
+            perms = [perm.replace(app_label, '') for perm in perms]
+            users[user] = sorted(perms)
         return users
 
 

--- a/guardian/testapp/tests/test_admin.py
+++ b/guardian/testapp/tests/test_admin.py
@@ -13,7 +13,7 @@ from guardian.admin import GuardedModelAdmin
 from guardian.compat import get_user_model, get_model_name
 from guardian.compat import reverse
 from guardian.compat import str
-from guardian.shortcuts import get_perms
+from guardian.shortcuts import get_perms, clear_cache
 from guardian.shortcuts import get_perms_for_model
 from guardian.testapp.tests.conf import TEST_SETTINGS
 from guardian.testapp.tests.conf import override_settings
@@ -169,6 +169,7 @@ class AdminTests(TestCase):
         )
 
         # Remove perm and check if change was persisted
+        clear_cache(self.user)
         perms = ['change_%s' % self.obj_info[1]]
         data = {'permissions': perms}
         response = self.client.post(url, data, follow=True)
@@ -273,6 +274,7 @@ class AdminTests(TestCase):
         )
 
         # Remove perm and check if change was persisted
+        clear_cache(self.group)
         perms = ['delete_%s' % self.obj_info[1]]
         data = {'permissions': perms}
         response = self.client.post(url, data, follow=True)

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -129,7 +129,7 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
         perms = sorted(chain(*Permission.objects
                              .filter(content_type=ctype)
                              .values_list('codename')))
-        self.assertEqual(perms, check.get_perms(self.ctype))
+        self.assertEqual(set(perms), check.get_perms(self.ctype))
         for perm in perms:
             self.assertTrue(check.has_perm(perm, self.ctype))
 

--- a/guardian/testapp/tests/test_mixins.py
+++ b/guardian/testapp/tests/test_mixins.py
@@ -9,7 +9,7 @@ from django.test.client import RequestFactory
 from django.views.generic import View
 from django.views.generic import ListView
 
-from guardian.shortcuts import assign_perm
+from guardian.shortcuts import assign_perm, clear_cache
 from guardian.compat import get_user_model
 import mock
 from guardian.mixins import LoginRequiredMixin
@@ -173,6 +173,7 @@ class TestViewMixins(TestCase):
                                                                     response, obj=self.post)
 
         request.user.add_obj_perm('add_post', self.post)
+        clear_cache(request.user)
         with self.assertRaises(DatabaseRemovedError):
             view(request)
 

--- a/guardian/testapp/tests/test_other.py
+++ b/guardian/testapp/tests/test_other.py
@@ -248,7 +248,6 @@ class ObjectPermissionBackendTests(TestCase):
         self.assertFalse(self.backend.has_perm(user, "change_user", self.user))
 
     def test_has_perm_wrong_app(self):
-        guardian_settings.ALLOW_CROSS_MODEL_PERMISSIONS=False
         self.assertRaises(WrongAppError, self.backend.has_perm,
                           self.user, "no_app.change_user", self.user)
 
@@ -258,6 +257,7 @@ class ObjectPermissionBackendTests(TestCase):
             self.backend.has_perm(self.user, "no_app.change_user", self.user)
         except WrongAppError:
             self.fail('WrongAppError raised erroneously!')
+        guardian_settings.ALLOW_CROSS_MODEL_PERMISSIONS=False
 
     def test_obj_is_not_model(self):
         for obj in (Group, 666, "String", [2, 1, 5, 7], {}):

--- a/guardian/testapp/tests/test_other.py
+++ b/guardian/testapp/tests/test_other.py
@@ -23,6 +23,7 @@ from guardian.exceptions import ObjectNotPersisted
 from guardian.exceptions import WrongAppError
 from guardian.models import GroupObjectPermission
 from guardian.models import UserObjectPermission
+from guardian.shortcuts import clear_cache
 from guardian.testapp.tests.conf import TestDataMixin
 User = get_user_model()
 user_model_path = get_user_model_path()
@@ -137,24 +138,26 @@ class GroupPermissionTests(TestDataMixin, TestCase):
         self.obj2 = ContentType.objects.create(
             model='bar', app_label='guardian-tests')
 
-    def test_assignement(self):
+    def test_assignment(self):
         self.assertFalse(self.user.has_perm('change_contenttype', self.ctype))
         self.assertFalse(self.user.has_perm('contenttypes.change_contenttype',
                                             self.ctype))
 
         GroupObjectPermission.objects.assign_perm('change_contenttype', self.group,
                                                   self.ctype)
+        clear_cache(self.user)
         self.assertTrue(self.user.has_perm('change_contenttype', self.ctype))
         self.assertTrue(self.user.has_perm('contenttypes.change_contenttype',
                                            self.ctype))
 
-    def test_assignement_and_remove(self):
+    def test_assignment_and_remove(self):
         GroupObjectPermission.objects.assign_perm('change_contenttype', self.group,
                                                   self.ctype)
         self.assertTrue(self.user.has_perm('change_contenttype', self.ctype))
 
         GroupObjectPermission.objects.remove_perm('change_contenttype',
                                                   self.group, self.ctype)
+        clear_cache(self.user)
         self.assertFalse(self.user.has_perm('change_contenttype', self.ctype))
 
     def test_ctypes(self):
@@ -167,6 +170,7 @@ class GroupPermissionTests(TestDataMixin, TestCase):
                                                   self.group, self.obj1)
         GroupObjectPermission.objects.assign_perm('change_contenttype', self.group,
                                                   self.obj2)
+        clear_cache(self.user)
         self.assertTrue(self.user.has_perm('change_contenttype', self.obj2))
         self.assertFalse(self.user.has_perm('change_contenttype', self.obj1))
 
@@ -174,6 +178,7 @@ class GroupPermissionTests(TestDataMixin, TestCase):
                                                   self.obj1)
         GroupObjectPermission.objects.assign_perm('change_contenttype', self.group,
                                                   self.obj2)
+        clear_cache(self.user)
         self.assertTrue(self.user.has_perm('change_contenttype', self.obj2))
         self.assertTrue(self.user.has_perm('change_contenttype', self.obj1))
 
@@ -181,6 +186,7 @@ class GroupPermissionTests(TestDataMixin, TestCase):
                                                   self.group, self.obj1)
         GroupObjectPermission.objects.remove_perm('change_contenttype',
                                                   self.group, self.obj2)
+        clear_cache(self.user)
         self.assertFalse(self.user.has_perm('change_contenttype', self.obj2))
         self.assertFalse(self.user.has_perm('change_contenttype', self.obj1))
 

--- a/guardian/testapp/tests/test_other.py
+++ b/guardian/testapp/tests/test_other.py
@@ -17,6 +17,7 @@ from guardian.compat import get_user_model_path
 from guardian.compat import get_user_permission_codename
 from guardian.compat import basestring
 from guardian.compat import unicode
+from guardian.conf import settings as guardian_settings
 from guardian.exceptions import GuardianError
 from guardian.exceptions import NotUserNorGroup
 from guardian.exceptions import ObjectNotPersisted
@@ -247,8 +248,16 @@ class ObjectPermissionBackendTests(TestCase):
         self.assertFalse(self.backend.has_perm(user, "change_user", self.user))
 
     def test_has_perm_wrong_app(self):
+        guardian_settings.ALLOW_CROSS_MODEL_PERMISSIONS=False
         self.assertRaises(WrongAppError, self.backend.has_perm,
                           self.user, "no_app.change_user", self.user)
+
+    def test_allow_cross_model_perms(self):
+        guardian_settings.ALLOW_CROSS_MODEL_PERMISSIONS=True
+        try:
+            self.backend.has_perm(self.user, "no_app.change_user", self.user)
+        except WrongAppError:
+            self.fail('WrongAppError raised erroneously!')
 
     def test_obj_is_not_model(self):
         for obj in (Group, 666, "String", [2, 1, 5, 7], {}):

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -81,6 +81,7 @@ class AssignPermTest(ObjectPermissionTestCase):
         assign_perm("add_contenttype", self.group, self.ctype)
         assign_perm("change_contenttype", self.group, self.ctype)
         assign_perm(self.get_permission("delete_contenttype"), self.group, self.ctype)
+        clear_cache(self.group) # event if the checker is newly constructed cache is transferred
 
         check = ObjectPermissionChecker(self.group)
         self.assertTrue(check.has_perm("add_contenttype", self.ctype))
@@ -91,8 +92,9 @@ class AssignPermTest(ObjectPermissionTestCase):
         assign_perm("add_contenttype", self.user, self.ctype_qset)
         assign_perm("change_contenttype", self.group, self.ctype_qset)
         assign_perm(self.get_permission("delete_contenttype"), self.user, self.ctype_qset)
-
         clear_cache(self.user)
+        clear_cache(self.group)
+
         for obj in self.ctype_qset:
             self.assertTrue(self.user.has_perm("add_contenttype", obj))
             self.assertTrue(self.user.has_perm("change_contenttype", obj))
@@ -214,11 +216,11 @@ class GetPermsTest(ObjectPermissionTestCase):
         perms_to_assign = ("change_contenttype",)
 
         for perm in perms_to_assign:
-            assign_perm("change_contenttype", self.user, self.ctype)
+            assign_perm(perm, self.user, self.ctype)
 
         perms = get_perms(self.user, self.ctype)
         for perm in perms_to_assign:
-            self.assertTrue(perm in perms)
+            self.assertIn(perm, perms)
 
 
 class GetUsersWithPermsTest(TestCase):
@@ -389,8 +391,10 @@ class GetUsersWithPermsTest(TestCase):
         self.assertEqual(set(get_group_perms(self.group1, self.obj1)), set(['delete_contenttype']))
         self.assertEqual(set(get_group_perms(self.group2, self.obj1)), set([]))
         self.assertEqual(set(get_group_perms(admin, self.obj1)), set([]))
-        self.assertEqual(set(get_perms(admin, self.obj1)), set(['add_contenttype', 'change_contenttype', 'delete_contenttype']))
-        self.assertEqual(set(get_perms(self.user1, self.obj1)), set(['change_contenttype', 'delete_contenttype']))
+        self.assertEqual(set(get_perms(admin, self.obj1)),
+                         set(['add_contenttype', 'change_contenttype', 'delete_contenttype']))
+        self.assertEqual(set(get_perms(self.user1, self.obj1)),
+                         set(['change_contenttype', 'delete_contenttype']))
         self.assertEqual(set(get_perms(self.user2, self.obj1)), set(['delete_contenttype']))
         self.assertEqual(set(get_perms(self.group1, self.obj1)), set(['delete_contenttype']))
         self.assertEqual(set(get_perms(self.group2, self.obj1)), set([]))

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models.query import QuerySet
 from django.test import TestCase
 
+from guardian.managers import clear_cache
 from guardian.shortcuts import get_perms_for_model
 from guardian.core import ObjectPermissionChecker
 from guardian.compat import get_user_model
@@ -90,6 +91,8 @@ class AssignPermTest(ObjectPermissionTestCase):
         assign_perm("add_contenttype", self.user, self.ctype_qset)
         assign_perm("change_contenttype", self.group, self.ctype_qset)
         assign_perm(self.get_permission("delete_contenttype"), self.user, self.ctype_qset)
+
+        clear_cache(self.user)
         for obj in self.ctype_qset:
             self.assertTrue(self.user.has_perm("add_contenttype", obj))
             self.assertTrue(self.user.has_perm("change_contenttype", obj))
@@ -101,6 +104,7 @@ class AssignPermTest(ObjectPermissionTestCase):
         assign_perm(self.get_permission("delete_contenttype"), self.group, self.ctype_qset)
 
         check = ObjectPermissionChecker(self.group)
+        check.clear_cache()
         for obj in self.ctype_qset:
             self.assertTrue(check.has_perm("add_contenttype", obj))
             self.assertTrue(check.has_perm("change_contenttype", obj))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django>=1.10.6
 six
 django-environ
 bumpversion
+mock


### PR DESCRIPTION
Attached `_obj_perms_cache` to user or group in order to maintain it between successive calls to `user.has_perm(perm, obj)`