### PR TITLE
Add kwarg to get_users_with_perms to filter for specific permissions as discussed in #246, #383 (rename, add tests)

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -212,7 +212,7 @@ def get_perms_for_model(cls):
 
 
 def get_users_with_perms(obj, attach_perms=False, with_superusers=False,
-                         with_group_users=True):
+                         with_group_users=True, only_with_perms=None):
     """
     Returns queryset of all ``User`` objects with *any* object permissions for
     the given ``obj``.
@@ -230,6 +230,10 @@ def get_users_with_perms(obj, attach_perms=False, with_superusers=False,
       **not** contain those users who have only group permissions for given
       ``obj``.
 
+    :param only_with_perms: Default: ``None``. If set to an iterable of
+      permission strings then only users with those permissions would be
+      returned.
+
     Example::
 
         >>> from django.contrib.flatpages.models import FlatPage
@@ -238,13 +242,17 @@ def get_users_with_perms(obj, attach_perms=False, with_superusers=False,
         >>>
         >>> page = FlatPage.objects.create(title='Some page', path='/some/page/')
         >>> joe = User.objects.create_user('joe', 'joe@example.com', 'joesecret')
+        >>> dan = User.objects.create_user('dan', 'dan@example.com', 'dansecret')
         >>> assign_perm('change_flatpage', joe, page)
+        >>> assign_perm('delete_flatpage', dan, page)
         >>>
         >>> get_users_with_perms(page)
-        [<User: joe>]
+        [<User: joe>, <User: dan>]
         >>>
         >>> get_users_with_perms(page, attach_perms=True)
-        {<User: joe>: [u'change_flatpage']}
+        {<User: joe>: [u'change_flatpage'], <User: dan>: [u'delete_flatpage']}
+        >>> get_users_with_perms(page, only_with_perms=['change_flatpage'])
+        [<User: joe>]
 
     """
     ctype = get_content_type(obj)
@@ -261,6 +269,14 @@ def get_users_with_perms(obj, attach_perms=False, with_superusers=False,
         else:
             user_filters = {'%s__content_object' % related_name: obj}
         qset = Q(**user_filters)
+        if only_with_perms is not None:
+            permission_qset = Q()
+            for permission in only_with_perms:
+                permission_qset |= Q(**{
+                    '%s__permission' % related_name: Permission.objects.get(
+                        content_type=ctype, codename=permission)
+                    })
+            qset &= permission_qset
         if with_group_users:
             group_model = get_group_obj_perms_model(obj)
             group_rel_name = group_model.group.field.related_query_name()
@@ -273,6 +289,11 @@ def get_users_with_perms(obj, attach_perms=False, with_superusers=False,
                 group_filters = {
                     'groups__%s__content_object' % group_rel_name: obj,
                 }
+            if only_with_perms is not None:
+                for permission in only_with_perms:
+                    group_filters.update({
+                            'groups__%s__permission' % group_rel_name: permission,
+                            })
             qset = qset | Q(**group_filters)
         if with_superusers:
             qset = qset | Q(is_superuser=True)
@@ -282,6 +303,7 @@ def get_users_with_perms(obj, attach_perms=False, with_superusers=False,
         users = {}
         for user in get_users_with_perms(obj,
                                          with_group_users=with_group_users,
+                                         only_with_perms=only_with_perms,
                                          with_superusers=with_superusers):
             # TODO: Support the case of set with_group_users but not with_superusers.
             if with_group_users or with_superusers:

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -256,6 +256,33 @@ class GetUsersWithPermsTest(TestCase):
             set([user.username for user in (self.user1, self.user2)]),
         )
 
+    def test_only_with_perms(self):
+        assign_perm("change_contenttype", self.user1, self.obj1)
+        assign_perm("delete_contenttype", self.user2, self.obj1)
+        assign_perm("delete_contenttype", self.user3, self.obj2)
+
+        result = get_users_with_perms(self.obj1, only_with_perms=('change_contenttype',))
+        result_vals = result.values_list('username', flat=True)
+
+        self.assertEqual(
+            set(result_vals),
+            set((self.user1.username,)),
+        )
+
+    def test_only_with_perms_attached(self):
+        assign_perm("change_contenttype", self.user1, self.obj1)
+        assign_perm("change_contenttype", self.user2, self.obj1)
+        assign_perm("delete_contenttype", self.user2, self.obj1)
+        assign_perm("delete_contenttype", self.user3, self.obj2)
+
+        result = get_users_with_perms(self.obj1, only_with_perms=('delete_contenttype',),
+            attach_perms=True)
+
+        expected = { self.user2 : ('change_contenttype', 'delete_contenttype') }
+        self.assertEqual(result.keys(), expected.keys())
+        for key, perms in result.items():
+            self.assertEqual(set(perms), set(expected[key]))
+
     def test_users_groups_perms(self):
         self.user1.groups.add(self.group1)
         self.user2.groups.add(self.group2)

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -256,12 +256,12 @@ class GetUsersWithPermsTest(TestCase):
             set([user.username for user in (self.user1, self.user2)]),
         )
 
-    def test_only_with_perms(self):
+    def test_only_with_perms_in(self):
         assign_perm("change_contenttype", self.user1, self.obj1)
         assign_perm("delete_contenttype", self.user2, self.obj1)
         assign_perm("delete_contenttype", self.user3, self.obj2)
 
-        result = get_users_with_perms(self.obj1, only_with_perms=('change_contenttype',))
+        result = get_users_with_perms(self.obj1, only_with_perms_in=('change_contenttype',))
         result_vals = result.values_list('username', flat=True)
 
         self.assertEqual(
@@ -269,13 +269,35 @@ class GetUsersWithPermsTest(TestCase):
             set((self.user1.username,)),
         )
 
-    def test_only_with_perms_attached(self):
+    def test_only_with_perms_in_and_with_group_users(self):
+        self.user1.groups.add(self.group1)
+        self.user2.groups.add(self.group2)
+        self.user3.groups.add(self.group3)
+
+        # assign perms to groups
+        assign_perm("change_contenttype", self.group1, self.obj1)
+        assign_perm("delete_contenttype", self.group2, self.obj1)
+        assign_perm("delete_contenttype", self.group3, self.obj2)
+
+        # assign perms to user
+        assign_perm("change_contenttype", self.user2, self.obj1)
+
+        result = get_users_with_perms(self.obj1, only_with_perms_in=('change_contenttype','delete_contenttype'), with_group_users=False)
+        result_vals = result.values_list('username', flat=True)
+
+        self.assertEqual(
+            set(result_vals),
+            set((self.user2.username,)),
+        )
+
+
+    def test_only_with_perms_in_attached(self):
         assign_perm("change_contenttype", self.user1, self.obj1)
         assign_perm("change_contenttype", self.user2, self.obj1)
         assign_perm("delete_contenttype", self.user2, self.obj1)
         assign_perm("delete_contenttype", self.user3, self.obj2)
 
-        result = get_users_with_perms(self.obj1, only_with_perms=('delete_contenttype',),
+        result = get_users_with_perms(self.obj1, only_with_perms_in=('delete_contenttype',),
             attach_perms=True)
 
         expected = { self.user2 : ('change_contenttype', 'delete_contenttype') }


### PR DESCRIPTION
Fix/Improve the functionality in #246 and #383. Also add tests.

I took code from the PR that @timabbott made and renamed the parameter to `only_with_perms_in` and added a test to check for proper behaviour with the `with_group_users` parameter to `False`.

I want this functionality in the library because I have a few models with multiple permissions so running a `get_users_with_perms` and then manually filtering the result gets old really fast.

@mitar might also be interested.