### PR TITLE
Simplified get_perms by using get_group_perms instead of repeating th…

### DIFF
--- a/guardian/core.py
+++ b/guardian/core.py
@@ -157,11 +157,7 @@ class ObjectPermissionChecker(object):
                 group_perms = self.get_group_perms(obj)
                 perms = list(set(chain(user_perms, group_perms)))
             else:
-                group_filters = self.get_group_filters(obj)
-                perms = list(set(chain(*Permission.objects
-                                       .filter(content_type=ctype)
-                                       .filter(**group_filters)
-                                       .values_list("codename"))))
+                perms = list(set(self.get_group_perms(obj)))
             self._obj_perms_cache[key] = perms
         return self._obj_perms_cache[key]
 


### PR DESCRIPTION
…e query that get_group_perms does for getting the permissions on a group object.

This basically lets you subclass the ObjectPermissionChecker and make your own backend to extend the functionality of the permission checking to look at other fields or do more complicated filtering on permissions.  An example would be adding expiration dates to object permissions, you would want to look for when the expiration is null or is greater than the current time.  With get_group_filters and get_user_filters it only supports and, not or.