### PR TITLE
Add makemigrations check in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ changedir =
     example: example_project
     docs: docs
 commands =
+    django110: python {toxinidir}/manage.py makemigrations --check --dry-run
+    django111: python {toxinidir}/manage.py makemigrations --check --dry-run
+    django20: python {toxinidir}/manage.py makemigrations --check --dry-run
     core: py.test --cov=guardian
     docs: sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
     example: python manage.py test


### PR DESCRIPTION
The change blocks the tests if there are pending migrations. It prevents oversight generate migration and ensures that migrations across all platforms behave consistently.