### PR TITLE
Allow for permission codenames containing `.`s

### DIFF
--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -82,16 +82,19 @@ class ObjectPermissionBackend(object):
             return False
 
         if '.' in perm:
-            app_label, perm = perm.split('.', 1)
-            if app_label != obj._meta.app_label:
-                # Check the content_type app_label when permission
-                # and obj app labels don't match.
-                ctype = get_content_type(obj)
-                if app_label != ctype.app_label:
-                    raise WrongAppError("Passed perm has app label of '%s' while "
-                                        "given obj has app label '%s' and given obj"
-                                        "content_type has app label '%s'" %
-                                        (app_label, obj._meta.app_label, ctype.app_label))
+            ctype = get_content_type(obj)
+            if perm.startswith('%s.' % obj._meta.app_label) \
+                or perm.startswith('%s.' % ctype):
+                perm = perm.split('.', 1)[-1]
+            # if app_label != obj._meta.app_label:
+            #     # Check the content_type app_label when permission
+            #     # and obj app labels don't match.
+            #     ctype = get_content_type(obj)
+            #     if app_label != ctype.app_label:
+            #         raise WrongAppError("Passed perm has app label of '%s' while "
+            #                             "given obj has app label '%s' and given obj"
+            #                             "content_type has app label '%s'" %
+            #                             (app_label, obj._meta.app_label, ctype.app_label))
 
         check = ObjectPermissionChecker(user_obj)
         return check.has_perm(perm, obj)

--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -82,7 +82,7 @@ class ObjectPermissionBackend(object):
             return False
 
         if '.' in perm:
-            app_label, perm = perm.split('.')
+            app_label, perm = perm.split('.', 1)
             if app_label != obj._meta.app_label:
                 # Check the content_type app_label when permission
                 # and obj app labels don't match.

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -71,7 +71,8 @@ class ObjectPermissionChecker(object):
             return False
         elif self.user and self.user.is_superuser:
             return True
-        perm = perm.split('.')[-1]
+        if perm.startswith('%s.' % get_content_type(obj)):
+            perm = perm.split('.', 1)[-1]
         return perm in self.get_perms(obj)
 
     def get_group_filters(self, obj):

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -71,7 +71,8 @@ class ObjectPermissionChecker(object):
             return False
         elif self.user and self.user.is_superuser:
             return True
-        if perm.startswith('%s.' % get_content_type(obj)):
+        if perm.startswith('%s.' % obj._meta.app_label) \
+            or perm.startswith('%s.' % get_content_type(obj)):
             perm = perm.split('.', 1)[-1]
         return perm in self.get_perms(obj)
 

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -90,7 +90,7 @@ def assign_perm(perm, user_or_group, obj=None):
             return perm
 
     if not isinstance(perm, Permission):
-        perm = perm.split('.')[-1]
+        perm = perm.split('.', 1)[-1]
 
     if isinstance(obj, QuerySet):
         if user:
@@ -151,7 +151,7 @@ def remove_perm(perm, user_or_group=None, obj=None):
             return
 
     if not isinstance(perm, Permission):
-        perm = perm.split('.')[-1]
+        perm = perm.split('.', 1)[-1]
 
     if isinstance(obj, QuerySet):
         if user:
@@ -203,7 +203,7 @@ def get_perms_for_model(cls):
     possible to pass Model as class or instance.
     """
     if isinstance(cls, basestring):
-        app_label, model_name = cls.split('.')
+        app_label, model_name = cls.split('.', 1)
         model = apps.get_model(app_label, model_name)
     else:
         model = cls

--- a/guardian/testapp/models.py
+++ b/guardian/testapp/models.py
@@ -96,6 +96,10 @@ class NonIntPKModel(models.Model):
     char_pk = models.CharField(primary_key=True, max_length=128)
 
 
+class CustomPermissionsModel(models.Model):
+    class Meta:
+        permissions = (('perm.with.dots', 'perm with dots'), )
+
 class CustomUser(AbstractUser, GuardianUserMixin):
     custom_id = models.AutoField(primary_key=True)
 

--- a/guardian/testapp/tests/test_other.py
+++ b/guardian/testapp/tests/test_other.py
@@ -23,6 +23,7 @@ from guardian.exceptions import ObjectNotPersisted
 from guardian.exceptions import WrongAppError
 from guardian.models import GroupObjectPermission
 from guardian.models import UserObjectPermission
+from guardian.testapp.models import CustomPermissionsModel
 from guardian.testapp.tests.conf import TestDataMixin
 User = get_user_model()
 user_model_path = get_user_model_path()
@@ -57,6 +58,18 @@ class UserPermissionTests(TestDataMixin, TestCase):
         UserObjectPermission.objects.remove_perm('change_contenttype',
                                                  self.user, self.ctype)
         self.assertFalse(self.user.has_perm('change_contenttype', self.ctype))
+
+    def test_assignement_and_remove_with_dots_in_codename(self):
+        obj = CustomPermissionsModel()
+        obj.save()
+
+        UserObjectPermission.objects.assign_perm('perm.with.dots', self.user,
+                                                 obj)
+        self.assertTrue(self.user.has_perm('perm.with.dots', obj))
+
+        UserObjectPermission.objects.remove_perm('perm.with.dots', self.user,
+                                                 obj)
+        self.assertFalse(self.user.has_perm('perm.with.dots', obj))
 
     def test_ctypes(self):
         UserObjectPermission.objects.assign_perm(


### PR DESCRIPTION
Limiting the `split()` operation here just like you guys already do in various functions in `guadian.shortcuts`
https://github.com/django-guardian/django-guardian/blob/devel/guardian/shortcuts.py#L78