### PR TITLE
Allow for UUID ids in admin url routing

### DIFF
--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -102,11 +102,11 @@ class GuardedModelAdminMixin(object):
                     view=self.admin_site.admin_view(
                         self.obj_perms_manage_view),
                     name='%s_%s_permissions' % info),
-                url(r'^(?P<object_pk>.+)/permissions/user-manage/(?P<user_id>\-?\d+)/$',
+                url(r'^(?P<object_pk>.+)/permissions/user-manage/(?P<user_id>.+)/$',
                     view=self.admin_site.admin_view(
                         self.obj_perms_manage_user_view),
                     name='%s_%s_permissions_manage_user' % info),
-                url(r'^(?P<object_pk>.+)/permissions/group-manage/(?P<group_id>\-?\d+)/$',
+                url(r'^(?P<object_pk>.+)/permissions/group-manage/(?P<group_id>.+)/$',
                     view=self.admin_site.admin_view(
                         self.obj_perms_manage_group_view),
                     name='%s_%s_permissions_manage_group' % info),


### PR DESCRIPTION
This was the only thing keeping django-guardian from completely working with my custom user model using UUID ids. 