### PR TITLE
Drop support for Django < 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,26 +4,19 @@ sudo: false
 cache: pip
 
 python:
- - 2.7
  - 3.4
  - 3.5
  - 3.6
 
 env:
- - DJANGO_VERSION=1.8 DATABASE_URL=postgres://postgres@/django_guardian
- - DJANGO_VERSION=1.10 DATABASE_URL=postgres://postgres@/django_guardian
  - DJANGO_VERSION=1.11 DATABASE_URL=postgres://postgres@/django_guardian
  - DJANGO_VERSION=2.0 DATABASE_URL=postgres://postgres@/django_guardian
  - DJANGO_VERSION=master DATABASE_URL=postgres://postgres@/django_guardian
 
- - DJANGO_VERSION=1.8 DATABASE_URL=mysql://root:@localhost/django_guardian
- - DJANGO_VERSION=1.10 DATABASE_URL=mysql://root:@localhost/django_guardian
  - DJANGO_VERSION=1.11 DATABASE_URL=mysql://root:@localhost/django_guardian
  - DJANGO_VERSION=2.0 DATABASE_URL=mysql://root:@localhost/django_guardian
  - DJANGO_VERSION=master DATABASE_URL=mysql://root:@localhost/django_guardian
 
- - DJANGO_VERSION=1.8 DATABASE_URL=sqlite://
- - DJANGO_VERSION=1.10 DATABASE_URL=sqlite://
  - DJANGO_VERSION=1.11 DATABASE_URL=sqlite://
  - DJANGO_VERSION=2.0 DATABASE_URL=sqlite://
  - DJANGO_VERSION=master DATABASE_URL=sqlite://
@@ -40,31 +33,19 @@ notifications:
 
 matrix:
   fast_finish: true
+  include:
+    - python: 2.7
+      env: DJANGO_VERSION=1.11 DATABASE_URL=postgres://postgres@/django_guardian
+    - python: 2.7
+      env: DJANGO_VERSION=1.11 DATABASE_URL=mysql://root:@localhost/django_guardian
+    - python: 2.7
+      env: DJANGO_VERSION=1.11 DATABASE_URL=sqlite://
   exclude:
-    - python: 2.7
-      env: DJANGO_VERSION=master DATABASE_URL=postgres://postgres@/django_guardian
-    - python: 2.7
-      env: DJANGO_VERSION=master DATABASE_URL=mysql://root:@localhost/django_guardian
-    - python: 2.7
-      env: DJANGO_VERSION=master DATABASE_URL=sqlite://
     - python: 3.4
       env: DJANGO_VERSION=master DATABASE_URL=postgres://postgres@/django_guardian
     - python: 3.4
       env: DJANGO_VERSION=master DATABASE_URL=mysql://root:@localhost/django_guardian
     - python: 3.4
-      env: DJANGO_VERSION=master DATABASE_URL=sqlite://
-    # Drop Python 2.7 django 2.0+
-    - python: 2.7
-      env: DJANGO_VERSION=2.0 DATABASE_URL=postgres://postgres@/django_guardian
-    - python: 2.7
-      env: DJANGO_VERSION=2.0 DATABASE_URL=mysql://root:@localhost/django_guardian
-    - python: 2.7
-      env: DJANGO_VERSION=2.0 DATABASE_URL=sqlite://
-    - python: 2.7
-      env: DJANGO_VERSION=master DATABASE_URL=postgres://postgres@/django_guardian
-    - python: 2.7
-      env: DJANGO_VERSION=master DATABASE_URL=mysql://root:@localhost/django_guardian
-    - python: 2.7
       env: DJANGO_VERSION=master DATABASE_URL=sqlite://
 
   allow_failures:

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@ Requirements
 ------------
 
 * Python 2.7 or 3.4+
-* A supported version of Django (currently 1.8+)
+* A supported version of Django (currently 1.11+)
 
-Travis CI tests on Django version 1.8, 1.10, 1.11 and 2.0.
+Travis CI tests on Django version 1.11, 2.0, and master.
 
 Installation
 ------------
@@ -41,7 +41,7 @@ We need to hook ``django-guardian`` into our project.
      ...
      'guardian',
     )
-   
+
 2. Add extra authorization backend to your ``settings.py``:
 
 .. code:: python

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -43,15 +43,6 @@ def random_string(length=25, chars=string.ascii_letters + string.digits):
     return ''.join(random.choice(chars) for i in range(length))
 
 
-def get_model_name(model):
-    """
-    Returns the name of the model
-    """
-    # model._meta.module_name is deprecated in django version 1.7 and removed in django version 1.8.
-    # It is replaced by model._meta.model_name
-    return model._meta.model_name
-
-
 class Call(object):
 
     def __init__(self, args, kwargs, start=None, finish=None):
@@ -100,7 +91,7 @@ class Benchmark(object):
         self.objects_with_perms_count = objects_with_perms_count
         self.subquery = subquery
         self.Model = model
-        self.perm = 'add_%s' % get_model_name(model)
+        self.perm = 'add_%s' % model._meta.model_name
 
     def info(self, msg):
         print(colorize(msg + '\n', fg='green'))

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -33,7 +33,7 @@ and hook guardian's authentication backend::
 
    .. code-block:: python
 
-      from guardian.compat import get_user_model
+      from django.contrib.auth import get_user_model
       User = get_user_model()
       anon = User.get_anonymous()
       anon.is_anonymous  # returns False

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -36,11 +36,11 @@ and hook guardian's authentication backend::
       from guardian.compat import get_user_model
       User = get_user_model()
       anon = User.get_anonymous()
-      anon.is_anonymous()   # returns False
+      anon.is_anonymous  # returns False
 
 We can change id to whatever we like. Project should be now ready to use object
 permissions.
- 
+
 
 Optional settings
 =================

--- a/docs/develop/supported-versions.rst
+++ b/docs/develop/supported-versions.rst
@@ -3,12 +3,12 @@
 Supported versions
 ==================
 
-``django-guardian`` supports Python 2.7+/3.3+ and Django 1.8+.
+``django-guardian`` supports Python 2.7+/3.3+ and Django 1.11+.
 
 Rules
 -----
 
 * We would support Python 2.7. We also support Python 3.4+.
 * Support for Python 3.4 may get dropped in the future.
-* We support Django 1.8+. This is due to many simplifications in code we could
+* We support Django 1.11+. This is due to many simplifications in code we could
   do.

--- a/example_project/articles/models.py
+++ b/example_project/articles/models.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from django.urls import reverse
 from django.utils.six import python_2_unicode_compatible
-from guardian.compat import reverse
 
 
 from guardian.models import GroupObjectPermissionBase, UserObjectPermissionBase

--- a/example_project/articles/tests.py
+++ b/example_project/articles/tests.py
@@ -1,6 +1,6 @@
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.test.client import RequestFactory
-from guardian.compat import get_user_model
 from guardian.shortcuts import assign_perm
 from articles.models import Article
 from articles.views import (ArticleCreateView, ArticleDeleteView, ArticleDetailView,

--- a/example_project/articles/views.py
+++ b/example_project/articles/views.py
@@ -1,6 +1,6 @@
+from django.urls import reverse_lazy
 from django.views.generic import (CreateView, DeleteView, DetailView, ListView,
                                   UpdateView)
-from guardian.compat import reverse_lazy
 from guardian.mixins import PermissionRequiredMixin, PermissionListMixin
 from guardian.shortcuts import assign_perm
 from articles.models import Article

--- a/example_project/core/migrations/0001_initial.py
+++ b/example_project/core/migrations/0001_initial.py
@@ -6,13 +6,6 @@ import django.utils.timezone
 import django.core.validators
 import django.contrib.auth.models
 
-if django.VERSION >= (1, 8):
-    django_version_depend = {'managers': [
-                ('objects', django.contrib.auth.models.UserManager()),
-            ]}
-else:
-    django_version_depend = {}
-
 
 class Migration(migrations.Migration):
 
@@ -57,6 +50,8 @@ class Migration(migrations.Migration):
                 'verbose_name': 'user',
                 'verbose_name_plural': 'users',
             },
-            **django_version_depend
+            managers=[
+                ('objects', django.contrib.auth.models.UserManager()),
+            ],
         ),
     ]

--- a/example_project/manage.py
+++ b/example_project/manage.py
@@ -3,9 +3,9 @@ import django
 import os
 import sys
 
-if django.VERSION < (1, 5):
+if django.VERSION < (1, 11):
     sys.stderr.write("ERROR: guardian's example project must be run with "
-                     "Django 1.8 or later!\n")
+                     "Django 1.11 or later!\n")
     sys.exit(1)
 
 

--- a/example_project/posts/models.py
+++ b/example_project/posts/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.urls import reverse
 from django.utils.six import python_2_unicode_compatible
 
 
@@ -18,6 +19,5 @@ class Post(models.Model):
     def __str__(self):
         return self.title
 
-    @models.permalink
     def get_absolute_url(self):
-        return ('posts_post_detail', (), {'slug': self.slug})
+        return reverse('posts_post_detail', args=(), kwargs={'slug': self.slug})

--- a/example_project/posts/views.py
+++ b/example_project/posts/views.py
@@ -1,9 +1,9 @@
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.shortcuts import render_to_response, get_object_or_404
 from django.views.generic import ListView
 from django.template import RequestContext
 from guardian.decorators import permission_required_or_403
-from guardian.compat import get_user_model
 
 from .models import Post
 

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -9,7 +9,6 @@ abspath = lambda *p: os.path.abspath(os.path.join(*p))
 
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 SECRET_KEY = 'CHANGE_THIS_TO_SOMETHING_UNIQUE_AND_SECURE'
 
 PROJECT_ROOT = abspath(os.path.dirname(__file__))
@@ -60,26 +59,6 @@ GUARDIAN_RAISE_403 = True
 
 ROOT_URLCONF = 'urls'
 
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'core.context_processors.version',
-    "django.contrib.auth.context_processors.auth",
-    "django.template.context_processors.debug",
-    "django.template.context_processors.i18n",
-    "django.template.context_processors.media",
-    "django.template.context_processors.static",
-    "django.template.context_processors.request",
-    "django.template.context_processors.tz",
-    "django.contrib.messages.context_processors.messages"
-)
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
-
-TEMPLATE_DIRS = (
-    os.path.join(os.path.dirname(__file__), 'templates'),
-)
-
 SITE_ID = 1
 
 USE_I18N = True
@@ -107,11 +86,26 @@ AUTH_USER_MODEL = 'core.CustomUser'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': TEMPLATE_DIRS,
+        'DIRS': (
+            os.path.join(os.path.dirname(__file__), 'templates'),
+        ),
         'OPTIONS': {
-            'debug': TEMPLATE_DEBUG,
-            'loaders': TEMPLATE_LOADERS,
-            'context_processors': TEMPLATE_CONTEXT_PROCESSORS,
+            'debug': DEBUG,
+            'loaders': (
+                'django.template.loaders.filesystem.Loader',
+                'django.template.loaders.app_directories.Loader',
+            ),
+            'context_processors': (
+                'core.context_processors.version',
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.request',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages'
+            ),
         },
     },
 ]

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -1,7 +1,7 @@
 from guardian.compat import include, url, handler404, handler500
 from django.conf import settings
 from django.contrib import admin
-from django.contrib.auth.views import logout
+from django.contrib.auth.views import LogoutView
 
 __all__ = ['handler404', 'handler500']
 
@@ -10,7 +10,7 @@ admin.autodiscover()
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^logout/$', logout, {'next_page': '/'}, name='logout'),
+    url(r'^logout/$', LogoutView.as_view(next_page='/'), name='logout'),
     url(r'^article/', include('articles.urls', namespace='articles')),
     url(r'^', include('posts.urls')),
 ]

--- a/guardian/__init__.py
+++ b/guardian/__init__.py
@@ -18,7 +18,7 @@ def get_version():
 
 
 def monkey_patch_user():
-    from .compat import get_user_model
+    from django.contrib.auth import get_user_model
     from .utils import get_anonymous_user
     from .models import UserObjectPermission
     User = get_user_model()

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -6,8 +6,7 @@ from django import forms
 from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.admin.widgets import FilteredSelectMultiple
-from django.shortcuts import get_object_or_404, redirect, render_to_response, render
-from django.template import RequestContext
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
@@ -16,8 +15,6 @@ from guardian.forms import GroupObjectPermissionsForm, UserObjectPermissionsForm
 from guardian.models import Group
 from guardian.shortcuts import (get_group_perms, get_groups_with_perms, get_perms_for_model, get_user_perms,
                                 get_users_with_perms)
-
-import django
 
 
 class AdminUserObjectPermissionsForm(UserObjectPermissionsForm):
@@ -61,12 +58,7 @@ class GuardedModelAdminMixin(object):
     include_object_permissions_urls = True
 
     def get_queryset(self, request):
-        # Prefer the Django >= 1.6 interface but maintain
-        # backward compatibility
-        method = getattr(
-            super(GuardedModelAdminMixin, self), 'get_queryset',
-            getattr(super(GuardedModelAdminMixin, self), 'queryset', None))
-        qs = method(request)
+        qs = super(GuardedModelAdminMixin, self).get_queryset(request)
 
         if request.user.is_superuser:
             return qs
@@ -118,13 +110,10 @@ class GuardedModelAdminMixin(object):
     def get_obj_perms_base_context(self, request, obj):
         """
         Returns context dictionary with common admin and object permissions
-        related content. It uses AdminSite.each_context (available in Django >= 1.8,
+        related content. It uses AdminSite.each_context,
         making sure all required template vars are in the context.
         """
-        if django.VERSION >= (1, 8):
-            context = self.admin_site.each_context(request)
-        else:
-            context = {}
+        context = self.admin_site.each_context(request)
         context.update( {
             'adminform': {'model_admin': self},
             'media': self.media,
@@ -150,12 +139,7 @@ class GuardedModelAdminMixin(object):
             post_url = reverse('admin:index', current_app=self.admin_site.name)
             return redirect(post_url)
 
-        try:
-            # django >= 1.7
-            from django.contrib.admin.utils import unquote
-        except ImportError:
-            # django < 1.7
-            from django.contrib.admin.util import unquote
+        from django.contrib.admin.utils import unquote
         obj = get_object_or_404(self.get_queryset(
             request), pk=unquote(object_pk))
         users_perms = OrderedDict(
@@ -217,10 +201,7 @@ class GuardedModelAdminMixin(object):
         # https://github.com/django/django/commit/cf1f36bb6eb34fafe6c224003ad585a647f6117b
         request.current_app = self.admin_site.name
 
-        if django.VERSION >= (1, 10):
-            return render(request, self.get_obj_perms_manage_template(), context)
-
-        return render_to_response(self.get_obj_perms_manage_template(), context, RequestContext(request))
+        return render(request, self.get_obj_perms_manage_template(), context)
 
     def get_obj_perms_manage_template(self):
         """
@@ -271,10 +252,7 @@ class GuardedModelAdminMixin(object):
 
         request.current_app = self.admin_site.name
 
-        if django.VERSION >= (1, 10):
-            return render(request, self.get_obj_perms_manage_user_template(), context)
-
-        return render_to_response(self.get_obj_perms_manage_user_template(), context, RequestContext(request))
+        return render(request, self.get_obj_perms_manage_user_template(), context)
 
     def get_obj_perms_manage_user_template(self):
         """
@@ -347,10 +325,7 @@ class GuardedModelAdminMixin(object):
 
         request.current_app = self.admin_site.name
 
-        if django.VERSION >= (1, 10):
-            return render(request, self.get_obj_perms_manage_group_template(), context)
-
-        return render_to_response(self.get_obj_perms_manage_group_template(), context, RequestContext(request))
+        return render(request, self.get_obj_perms_manage_group_template(), context)
 
     def get_obj_perms_manage_group_template(self):
         """

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -8,9 +8,10 @@ from django.contrib import admin, messages
 from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.shortcuts import get_object_or_404, redirect, render_to_response, render
 from django.template import RequestContext
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
-from guardian.compat import get_user_model, url, reverse
+from guardian.compat import get_user_model, url
 from guardian.forms import GroupObjectPermissionsForm, UserObjectPermissionsForm
 from guardian.models import Group
 from guardian.shortcuts import (get_group_perms, get_groups_with_perms, get_perms_for_model, get_user_perms,

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -10,7 +10,7 @@ from django.shortcuts import get_object_or_404, redirect, render_to_response, re
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
-from guardian.compat import get_model_name, get_user_model, url, reverse
+from guardian.compat import get_user_model, url, reverse
 from guardian.forms import GroupObjectPermissionsForm, UserObjectPermissionsForm
 from guardian.models import Group
 from guardian.shortcuts import (get_group_perms, get_groups_with_perms, get_perms_for_model, get_user_perms,
@@ -96,7 +96,7 @@ class GuardedModelAdminMixin(object):
         """
         urls = super(GuardedModelAdminMixin, self).get_urls()
         if self.include_object_permissions_urls:
-            info = self.model._meta.app_label, get_model_name(self.model)
+            info = self.model._meta.app_label, self.model._meta.model_name
             myurls = [
                 url(r'^(?P<object_pk>.+)/permissions/$',
                     view=self.admin_site.admin_view(
@@ -179,7 +179,7 @@ class GuardedModelAdminMixin(object):
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
-                get_model_name(self.model)
+                self.model._meta.model_name,
             )
             if user_form.is_valid():
                 user_id = user_form.cleaned_data['user'].pk
@@ -194,7 +194,7 @@ class GuardedModelAdminMixin(object):
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
-                get_model_name(self.model)
+                self.model._meta.model_name,
             )
             if group_form.is_valid():
                 group_id = group_form.cleaned_data['group'].id
@@ -255,7 +255,7 @@ class GuardedModelAdminMixin(object):
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
-                get_model_name(self.model)
+                self.model._meta.model_name,
             )
             url = reverse(
                 '%s:%s_%s_permissions_manage_user' % info,
@@ -331,7 +331,7 @@ class GuardedModelAdminMixin(object):
             info = (
                 self.admin_site.name,
                 self.model._meta.app_label,
-                get_model_name(self.model)
+                self.model._meta.model_name,
             )
             url = reverse(
                 '%s:%s_%s_permissions_manage_group' % info,

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -6,11 +6,12 @@ from django import forms
 from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.admin.widgets import FilteredSelectMultiple
+from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
-from guardian.compat import get_user_model, url
+from guardian.compat import url
 from guardian.forms import GroupObjectPermissionsForm, UserObjectPermissionsForm
 from guardian.models import Group
 from guardian.shortcuts import (get_group_perms, get_groups_with_perms, get_perms_for_model, get_user_perms,

--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
+from django.contrib.auth import get_user_model
 from django.db import models
-from guardian.compat import get_user_model
 from guardian.conf import settings
 from guardian.core import ObjectPermissionChecker
 from guardian.ctypes import get_content_type

--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from django.db import models
-from guardian.compat import get_user_model, is_authenticated
+from guardian.compat import get_user_model
 from guardian.conf import settings
 from guardian.core import ObjectPermissionChecker
 from guardian.ctypes import get_content_type
@@ -27,7 +27,7 @@ def check_user_support(user_obj):
     """
     # This is how we support anonymous users - simply try to retrieve User
     # instance and perform checks for that predefined user
-    if not is_authenticated(user_obj):
+    if not user_obj.is_authenticated:
         # If anonymous user permission is disabled then they are always
         # unauthorized
         if settings.ANONYMOUS_USER_NAME is None:

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -126,19 +126,10 @@ def template_debug_getter():
 
 
 # Django 1.9 compatibility
-def remote_field(field):
-    """
-    https://docs.djangoproject.com/en/1.9/releases/1.9/#field-rel-changes
-    """
-    if django.VERSION < (1, 9):
-        return field.rel
-    return field.remote_field
-
-
 def remote_model(field):
     if django.VERSION < (1, 9):
-        return remote_field(field).to
-    return remote_field(field).model
+        return field.rel.to
+    return field.remote_field.model
 
 
 # Django 1.10 compatibility

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -15,7 +15,6 @@ __all__ = [
     'Permission',
     'AnonymousUser',
     'get_user_model',
-    'import_string',
     'user_model_label',
     'url',
     'patterns',
@@ -65,29 +64,6 @@ def get_user_permission_codename(perm):
     ``myapp.CustomUser`` is used it would return ``change_customuser``.
     """
     return get_user_permission_full_codename(perm).split('.')[1]
-
-
-def import_string(dotted_path):
-    """
-    Import a dotted module path and return the attribute/class designated by the
-    last name in the path. Raise ImportError if the import failed.
-
-    Backported from Django 1.7
-    """
-    try:
-        module_path, class_name = dotted_path.rsplit('.', 1)
-    except ValueError:
-        msg = "%s doesn't look like a module path" % dotted_path
-        six.reraise(ImportError, ImportError(msg), sys.exc_info()[2])
-
-    module = import_module(module_path)
-
-    try:
-        return getattr(module, class_name)
-    except AttributeError:
-        msg = 'Module "%s" does not define a "%s" attribute/class' % (
-            dotted_path, class_name)
-        six.reraise(ImportError, ImportError(msg), sys.exc_info()[2])
 
 
 # Python 3

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -11,14 +11,12 @@ import six
 import sys
 
 __all__ = [
-    'User',
     'Group',
     'Permission',
     'AnonymousUser',
     'get_user_model',
     'user_model_label',
     'url',
-    'patterns',
     'include',
     'handler404',
     'handler500',
@@ -79,5 +77,3 @@ def create_permissions(*args, **kwargs):
     if len(args) > 1 and isinstance(args[1], (list, tuple)):
         args = args[:1] + args[2:]
     return original_create_permissions(*args, **kwargs)
-
-__all__ = ['User', 'Group', 'Permission', 'AnonymousUser']

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.conf.urls import handler404, handler500, include, url
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Group, Permission
 from importlib import import_module
 
@@ -23,18 +24,11 @@ __all__ = [
     'handler500',
 ]
 
-# Django 1.5 compatibility utilities, providing support for custom User models.
 # Since get_user_model() causes a circular import if called when app models are
 # being loaded, the user_model_label should be used when possible, with calls
 # to get_user_model deferred to execution time
 
 user_model_label = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
-
-try:
-    from django.contrib.auth import get_user_model
-except ImportError:
-    from django.contrib.auth.models import User
-    get_user_model = lambda: User
 
 
 def get_user_model_path():

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -126,17 +126,6 @@ def template_debug_getter():
 
 
 # Django 1.10 compatibility
-def is_authenticated(user):
-    if django.VERSION < (1, 10):
-        return user.is_authenticated()
-    return user.is_authenticated
-
-
-def is_anonymous(user):
-    if django.VERSION < (1, 10):
-        return user.is_anonymous()
-    return user.is_anonymous
-
 try:
     from django.urls import reverse, reverse_lazy
 except ImportError:

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -125,13 +125,6 @@ def template_debug_getter():
     return settings.TEMPLATES[0]['OPTIONS'].get('DEBUG', False)
 
 
-# Django 1.9 compatibility
-def remote_model(field):
-    if django.VERSION < (1, 9):
-        return field.rel.to
-    return field.remote_field.model
-
-
 # Django 1.10 compatibility
 def is_authenticated(user):
     if django.VERSION < (1, 10):

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -81,15 +81,3 @@ def create_permissions(*args, **kwargs):
     return original_create_permissions(*args, **kwargs)
 
 __all__ = ['User', 'Group', 'Permission', 'AnonymousUser']
-
-
-def template_debug_setter(value):
-    if hasattr(settings, 'TEMPLATE_DEBUG'):
-        settings.TEMPLATE_DEBUG = value
-    settings.TEMPLATES[0]['OPTIONS']['DEBUG'] = value
-
-
-def template_debug_getter():
-    if hasattr(settings, 'TEMPLATE_DEBUG'):
-        return settings.TEMPLATE_DEBUG
-    return settings.TEMPLATES[0]['OPTIONS'].get('DEBUG', False)

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -123,10 +123,3 @@ def template_debug_getter():
     if hasattr(settings, 'TEMPLATE_DEBUG'):
         return settings.TEMPLATE_DEBUG
     return settings.TEMPLATES[0]['OPTIONS'].get('DEBUG', False)
-
-
-# Django 1.10 compatibility
-try:
-    from django.urls import reverse, reverse_lazy
-except ImportError:
-    from django.core.urlresolvers import reverse, reverse_lazy

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -113,15 +113,6 @@ def create_permissions(*args, **kwargs):
 __all__ = ['User', 'Group', 'Permission', 'AnonymousUser']
 
 
-def get_model_name(model):
-    """
-    Returns the name of the model
-    """
-    # model._meta.module_name is deprecated in django version 1.7 and removed
-    # in django version 1.8.  It is replaced by model._meta.model_name
-    return model._meta.model_name
-
-
 def template_debug_setter(value):
     if hasattr(settings, 'TEMPLATE_DEBUG'):
         settings.TEMPLATE_DEBUG = value

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.db.models.query import QuerySet
 from django.utils.encoding import force_text
-from guardian.compat import get_user_model
 from guardian.ctypes import get_content_type
 from guardian.utils import get_group_obj_perms_model, get_identity, get_user_obj_perms_model
 from itertools import chain

--- a/guardian/ctypes.py
+++ b/guardian/ctypes.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals
 
 from django.contrib.contenttypes.models import ContentType
+from django.utils.module_loading import import_string
 
 from guardian.conf import settings as guardian_settings
-from guardian.compat import import_string
 
 
 def get_content_type(obj):

--- a/guardian/management/__init__.py
+++ b/guardian/management/__init__.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
 
 import django
+from django.contrib.auth import get_user_model
 from django.db.models import signals
 from django.utils.module_loading import import_string
 
 from guardian.conf import settings as guardian_settings
-from guardian.compat import get_user_model
 
 
 def get_init_anonymous_user(User):

--- a/guardian/management/__init__.py
+++ b/guardian/management/__init__.py
@@ -2,10 +2,10 @@ from __future__ import unicode_literals
 
 import django
 from django.db.models import signals
+from django.utils.module_loading import import_string
 
 from guardian.conf import settings as guardian_settings
 from guardian.compat import get_user_model
-from guardian.compat import import_string
 
 
 def get_init_anonymous_user(User):

--- a/guardian/models.py
+++ b/guardian/models.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -8,11 +9,6 @@ from django.utils.translation import ugettext_lazy as _
 from guardian.compat import unicode, user_model_label
 from guardian.ctypes import get_content_type
 from guardian.managers import GroupObjectPermissionManager, UserObjectPermissionManager
-
-try:
-    from django.contrib.contenttypes.fields import GenericForeignKey
-except ImportError:
-    from django.contrib.contenttypes.generic import GenericForeignKey
 
 
 @python_2_unicode_compatible

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -13,7 +13,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, Q, QuerySet
 from django.shortcuts import _get_queryset
 
-from guardian.compat import basestring, get_user_model, is_anonymous
+from guardian.compat import basestring, get_user_model
 from guardian.core import ObjectPermissionChecker
 from guardian.ctypes import get_content_type
 from guardian.exceptions import MixedContentTypeError, WrongAppError
@@ -523,7 +523,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
     # Check if the user is anonymous. The
     # django.contrib.auth.models.AnonymousUser object doesn't work for queries
     # and it's nice to be able to pass in request.user blindly.
-    if is_anonymous(user):
+    if user.is_anonymous:
         user = get_anonymous_user()
 
     global_perms = set()

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -8,12 +8,13 @@ from collections import defaultdict
 from itertools import groupby
 
 from django.apps import apps
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count, Q, QuerySet
 from django.shortcuts import _get_queryset
 
-from guardian.compat import basestring, get_user_model
+from guardian.compat import basestring
 from guardian.core import ObjectPermissionChecker
 from guardian.ctypes import get_content_type
 from guardian.exceptions import MixedContentTypeError, WrongAppError

--- a/guardian/templatetags/guardian_tags.py
+++ b/guardian/templatetags/guardian_tags.py
@@ -8,9 +8,9 @@
 from __future__ import unicode_literals
 
 from django import template
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Group
 
-from guardian.compat import get_user_model
 from guardian.core import ObjectPermissionChecker
 from guardian.exceptions import NotUserNorGroup
 
@@ -42,7 +42,7 @@ class ObjectPermissionsNode(template.Node):
         obj = self.obj.resolve(context)
         if not obj:
             return ''
-        
+
         check = self.checker.resolve(context) if self.checker else ObjectPermissionChecker(for_whom)
         perms = check.get_perms(obj)
 

--- a/guardian/testapp/tests/conf.py
+++ b/guardian/testapp/tests/conf.py
@@ -8,15 +8,6 @@ from django.conf import UserSettingsHolder
 from django.utils.functional import wraps
 
 
-THIS = abspath(os.path.dirname(__file__))
-TEST_TEMPLATES_DIR = abspath(THIS, 'templates')
-
-
-TEST_SETTINGS = dict(
-    TEMPLATE_DIRS=[TEST_TEMPLATES_DIR],
-)
-
-
 def skipUnlessTestApp(obj):
     app = 'guardian.testapp'
     return unittest.skipUnless(app in settings.INSTALLED_APPS,

--- a/guardian/testapp/tests/conf.py
+++ b/guardian/testapp/tests/conf.py
@@ -19,11 +19,8 @@ class TestDataMixin(object):
     def setUp(self):
         super(TestDataMixin, self).setUp()
         from django.contrib.auth.models import Group
-        try:
-            from django.contrib.auth import get_user_model
-            User = get_user_model()
-        except ImportError:
-            from django.contrib.auth.models import User
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
         Group.objects.create(pk=1, name='admins')
         jack_group = Group.objects.create(pk=2, name='jackGroup')
         User.objects.get_or_create(username=guardian_settings.ANONYMOUS_USER_NAME)

--- a/guardian/testapp/tests/test_admin.py
+++ b/guardian/testapp/tests/test_admin.py
@@ -4,6 +4,7 @@ import copy
 from django import forms
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.http import HttpRequest
 from django.test import TestCase
@@ -11,7 +12,6 @@ from django.test.client import Client
 from django.urls import reverse
 
 from guardian.admin import GuardedModelAdmin
-from guardian.compat import get_user_model
 from guardian.compat import str
 from guardian.shortcuts import get_perms
 from guardian.shortcuts import get_perms_for_model

--- a/guardian/testapp/tests/test_admin.py
+++ b/guardian/testapp/tests/test_admin.py
@@ -8,10 +8,10 @@ from django.contrib.contenttypes.models import ContentType
 from django.http import HttpRequest
 from django.test import TestCase
 from django.test.client import Client
+from django.urls import reverse
 
 from guardian.admin import GuardedModelAdmin
 from guardian.compat import get_user_model
-from guardian.compat import reverse
 from guardian.compat import str
 from guardian.shortcuts import get_perms
 from guardian.shortcuts import get_perms_for_model

--- a/guardian/testapp/tests/test_admin.py
+++ b/guardian/testapp/tests/test_admin.py
@@ -10,7 +10,7 @@ from django.test import TestCase
 from django.test.client import Client
 
 from guardian.admin import GuardedModelAdmin
-from guardian.compat import get_user_model, get_model_name
+from guardian.compat import get_user_model
 from guardian.compat import reverse
 from guardian.compat import str
 from guardian.shortcuts import get_perms
@@ -45,7 +45,7 @@ class AdminTests(TestCase):
         self.client = Client()
         self.obj = ContentType.objects.create(
             model='bar', app_label='fake-for-guardian-tests')
-        self.obj_info = self.obj._meta.app_label, get_model_name(self.obj)
+        self.obj_info = self.obj._meta.app_label, self.obj._meta.model_name
 
     def tearDown(self):
         self.client.logout()

--- a/guardian/testapp/tests/test_admin.py
+++ b/guardian/testapp/tests/test_admin.py
@@ -15,8 +15,6 @@ from guardian.admin import GuardedModelAdmin
 from guardian.compat import str
 from guardian.shortcuts import get_perms
 from guardian.shortcuts import get_perms_for_model
-from guardian.testapp.tests.conf import TEST_SETTINGS
-from guardian.testapp.tests.conf import override_settings
 from guardian.models import Group
 from guardian.testapp.tests.conf import skipUnlessTestApp
 from guardian.testapp.models import LogEntryWithGroup as LogEntry
@@ -34,7 +32,6 @@ except admin.sites.NotRegistered:
 admin.site.register(ContentType, ContentTypeGuardedAdmin)
 
 
-@override_settings(**TEST_SETTINGS)
 class AdminTests(TestCase):
 
     def setUp(self):

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -9,12 +9,13 @@ try:
     auth_app = django_apps.get_app_config("auth")
 except ImportError:
     from django.contrib.auth import models as auth_app
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from guardian.core import ObjectPermissionChecker
-from guardian.compat import get_user_model, create_permissions
+from guardian.compat import create_permissions
 from guardian.exceptions import NotUserNorGroup
 from guardian.models import UserObjectPermission, GroupObjectPermission
 from guardian.shortcuts import assign_perm

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -3,12 +3,7 @@ from itertools import chain
 
 from django.conf import settings
 from guardian.conf import settings as guardian_settings
-# Try the new app settings (Django 1.7) and fall back to the old system
-try:
-    from django.apps import apps as django_apps
-    auth_app = django_apps.get_app_config("auth")
-except ImportError:
-    from django.contrib.auth import models as auth_app
+from django.apps import apps as django_apps
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
@@ -23,6 +18,7 @@ from guardian.management import create_anonymous_user
 
 from guardian.testapp.models import Project
 
+auth_app = django_apps.get_app_config('auth')
 User = get_user_model()
 
 

--- a/guardian/testapp/tests/test_custompkmodel.py
+++ b/guardian/testapp/tests/test_custompkmodel.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
-from guardian.compat import get_user_model
 from guardian.shortcuts import assign_perm, remove_perm
 
 

--- a/guardian/testapp/tests/test_decorators.py
+++ b/guardian/testapp/tests/test_decorators.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 from django.conf import settings, global_settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, AnonymousUser
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db.models.base import ModelBase
@@ -12,7 +13,6 @@ from django.shortcuts import get_object_or_404
 from django.template import TemplateDoesNotExist
 from django.test import TestCase
 
-from guardian.compat import get_user_model
 from guardian.compat import get_user_model_path
 from guardian.compat import get_user_permission_full_codename
 import mock

--- a/guardian/testapp/tests/test_decorators.py
+++ b/guardian/testapp/tests/test_decorators.py
@@ -20,7 +20,6 @@ from guardian.decorators import permission_required, permission_required_or_403,
 from guardian.exceptions import GuardianError
 from guardian.exceptions import WrongAppError
 from guardian.shortcuts import assign_perm
-from guardian.testapp.tests.conf import TEST_SETTINGS
 from guardian.testapp.tests.conf import TestDataMixin
 from guardian.testapp.tests.conf import override_settings
 from guardian.testapp.tests.conf import skipUnlessTestApp
@@ -30,7 +29,6 @@ User = get_user_model()
 user_model_path = get_user_model_path()
 
 
-@override_settings(**TEST_SETTINGS)
 @skipUnlessTestApp
 class PermissionRequiredTest(TestDataMixin, TestCase):
 

--- a/guardian/testapp/tests/test_direct_rel.py
+++ b/guardian/testapp/tests/test_direct_rel.py
@@ -1,9 +1,9 @@
 from __future__ import unicode_literals
 
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
 
-from guardian.compat import get_user_model
 from guardian.shortcuts import assign_perm
 from guardian.shortcuts import get_groups_with_perms
 from guardian.shortcuts import get_objects_for_group

--- a/guardian/testapp/tests/test_forms.py
+++ b/guardian/testapp/tests/test_forms.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
 
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
-from guardian.compat import get_user_model
 from guardian.forms import BaseObjectPermissionsForm
 
 

--- a/guardian/testapp/tests/test_management.py
+++ b/guardian/testapp/tests/test_management.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 
-from guardian.compat import get_user_model
 import mock
 from guardian.management import create_anonymous_user
 from guardian.utils import get_anonymous_user

--- a/guardian/testapp/tests/test_mixins.py
+++ b/guardian/testapp/tests/test_mixins.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
 from django.core.exceptions import PermissionDenied
@@ -10,7 +11,6 @@ from django.views.generic import View
 from django.views.generic import ListView
 
 from guardian.shortcuts import assign_perm
-from guardian.compat import get_user_model
 import mock
 from guardian.mixins import LoginRequiredMixin
 from guardian.mixins import PermissionRequiredMixin

--- a/guardian/testapp/tests/test_orphans.py
+++ b/guardian/testapp/tests/test_orphans.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
 from django.test import TestCase
 
-from guardian.compat import get_user_model, create_permissions, get_model_name
+from guardian.compat import get_user_model, create_permissions
 from guardian.utils import clean_orphan_obj_perms
 from guardian.shortcuts import assign_perm
 from guardian.models import Group
@@ -15,7 +15,7 @@ from guardian.testapp.tests.conf import skipUnlessTestApp
 
 
 User = get_user_model()
-user_module_name = get_model_name(User)
+user_module_name = User._meta.model_name
 
 
 @skipUnlessTestApp

--- a/guardian/testapp/tests/test_orphans.py
+++ b/guardian/testapp/tests/test_orphans.py
@@ -3,11 +3,12 @@ from __future__ import unicode_literals
 from django.apps import apps as django_apps
 auth_app = django_apps.get_app_config("auth")
 
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
 from django.test import TestCase
 
-from guardian.compat import get_user_model, create_permissions
+from guardian.compat import create_permissions
 from guardian.utils import clean_orphan_obj_perms
 from guardian.shortcuts import assign_perm
 from guardian.models import Group

--- a/guardian/testapp/tests/test_other.py
+++ b/guardian/testapp/tests/test_other.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import mock
 import unittest
 
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.auth.models import Group
 from django.contrib.auth.models import Permission
@@ -12,7 +13,6 @@ from django.test import TestCase
 
 import guardian
 from guardian.backends import ObjectPermissionBackend
-from guardian.compat import get_user_model
 from guardian.compat import get_user_model_path
 from guardian.compat import get_user_permission_codename
 from guardian.compat import basestring
@@ -289,7 +289,7 @@ class TestExceptions(TestCase):
 @unittest.skip("test is broken")
 class TestMonkeyPatch(TestCase):
 
-    @mock.patch('guardian.compat.get_user_model')
+    @mock.patch('django.contrib.auth.get_user_model')
     def test_monkey_patch(self, mocked_get_user_model):
         # Import AbstractUser here as it is only available since Django 1.5
         from django.contrib.auth.models import AbstractUser

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -165,7 +165,7 @@ class RemovePermTest(ObjectPermissionTestCase):
         assign_perm("change_contenttype", self.user, self.ctype_qset)
         remove_perm("change_contenttype", self.user, self.ctype_qset.none())
 
-        self.assertEquals(list(self.ctype_qset.none()), [])
+        self.assertEqual(list(self.ctype_qset.none()), [])
         for obj in self.ctype_qset:
             self.assertTrue(self.user.has_perm("change_contenttype", obj))
 
@@ -1124,7 +1124,7 @@ class GetObjectsForGroup(TestCase):
 
         objects = get_objects_for_group(
             self.group1, ['contenttypes.change_contenttype'])
-        self.assertEquals(set(objects),
+        self.assertEqual(set(objects),
                           set(ContentType.objects.all()))
 
     def test_has_global_permission_and_object_based_permission(self):
@@ -1133,7 +1133,7 @@ class GetObjectsForGroup(TestCase):
 
         objects = get_objects_for_group(self.group1, [
                                         'contenttypes.change_contenttype', 'contenttypes.delete_contenttype'], any_perm=False)
-        self.assertEquals(set(objects),
+        self.assertEqual(set(objects),
                           set([self.obj1]))
 
     def test_has_global_permission_and_object_based_permission_any_perm(self):
@@ -1142,7 +1142,7 @@ class GetObjectsForGroup(TestCase):
 
         objects = get_objects_for_group(self.group1, [
                                         'contenttypes.change_contenttype', 'contenttypes.delete_contenttype'], any_perm=True)
-        self.assertEquals(set(objects),
+        self.assertEqual(set(objects),
                           set(ContentType.objects.all()))
 
     def test_has_global_permission_and_object_based_permission_3perms(self):
@@ -1152,7 +1152,7 @@ class GetObjectsForGroup(TestCase):
 
         objects = get_objects_for_group(self.group1, [
                                         'contenttypes.change_contenttype', 'contenttypes.delete_contenttype',  'contenttypes.add_contenttype'], any_perm=False)
-        self.assertEquals(set(objects),
+        self.assertEqual(set(objects),
                           set())
 
     def test_exception_different_ctypes(self):

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.query import QuerySet
@@ -7,7 +8,6 @@ from django.test import TestCase
 
 from guardian.shortcuts import get_perms_for_model
 from guardian.core import ObjectPermissionChecker
-from guardian.compat import get_user_model
 from guardian.compat import get_user_permission_full_codename
 from guardian.shortcuts import assign
 from guardian.shortcuts import assign_perm

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from guardian.shortcuts import get_perms_for_model
 from guardian.core import ObjectPermissionChecker
 from guardian.compat import get_user_model
-from guardian.compat import get_user_permission_full_codename, get_model_name
+from guardian.compat import get_user_permission_full_codename
 from guardian.shortcuts import assign
 from guardian.shortcuts import assign_perm
 from guardian.shortcuts import remove_perm
@@ -31,7 +31,7 @@ import warnings
 
 User = get_user_model()
 user_app_label = User._meta.app_label
-user_module_name = get_model_name(User)
+user_module_name = User._meta.model_name
 
 
 class ShortcutsTests(ObjectPermissionTestCase):

--- a/guardian/testapp/tests/test_tags.py
+++ b/guardian/testapp/tests/test_tags.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.template import Template, Context, TemplateSyntaxError
 from django.test import TestCase
 
-from guardian.compat import template_debug_getter, template_debug_setter
 from guardian.core import ObjectPermissionChecker
 from guardian.exceptions import NotUserNorGroup
 from guardian.models import UserObjectPermission, GroupObjectPermission
@@ -83,11 +83,12 @@ class GetObjPermsTagTest(TestCase):
         ))
         context = {'some_obj': ContentType(), 'contenttype': self.ctype}
         # This test would raise TemplateSyntaxError instead of NotUserNorGroup
-        # if TEMPLATE_DEBUG is set to True during tests
-        tmp = template_debug_getter()
-        template_debug_setter(False)
+        # if the template option 'debug' is set to True during tests.
+        template_options = settings.TEMPLATES[0]['OPTIONS']
+        tmp = template_options.get('debug', False)
+        template_options['debug'] = False
         self.assertRaises(NotUserNorGroup, render, template, context)
-        template_debug_setter(tmp)
+        template_options['debug'] = tmp
 
     def test_superuser(self):
         user = User.objects.create(username='superuser', is_superuser=True)

--- a/guardian/testapp/tests/test_tags.py
+++ b/guardian/testapp/tests/test_tags.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
 
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.template import Template, Context, TemplateSyntaxError
 from django.test import TestCase
 
-from guardian.compat import get_user_model, template_debug_getter, template_debug_setter
+from guardian.compat import template_debug_getter, template_debug_setter
 from guardian.core import ObjectPermissionChecker
 from guardian.exceptions import NotUserNorGroup
 from guardian.models import UserObjectPermission, GroupObjectPermission
@@ -132,14 +133,14 @@ class GetObjPermsTagTest(TestCase):
         output = render(template, context)
 
         self.assertEqual(output, 'delete_contenttype')
-        
+
     def test_checker(self):
         GroupObjectPermission.objects.assign_perm("delete_contenttype", self.group,
                                                           self.ctype)
 
         checker = ObjectPermissionChecker(self.user)
         checker.prefetch_perms(Group.objects.all())
-                
+
         template = ''.join((
             '{% load guardian_tags %}',
             '{% get_obj_perms group for contenttype as "obj_perms" checker %}',

--- a/guardian/testapp/tests/test_utils.py
+++ b/guardian/testapp/tests/test_utils.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals
 from django.test import TestCase
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import Group, AnonymousUser
 from django.db import models
 
-from guardian.compat import get_user_model
 from guardian.testapp.tests.conf import skipUnlessTestApp
 from guardian.testapp.tests.test_core import ObjectPermissionTestCase
 from guardian.testapp.models import Project

--- a/guardian/testapp/tests/urls.py
+++ b/guardian/testapp/tests/urls.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from guardian.compat import include, url, handler404, handler500  # pyflakes:ignore
 from guardian.mixins import PermissionRequiredMixin
 from django.contrib import admin
-from django.contrib.auth.views import login
+from django.contrib.auth.views import LoginView
 from django.views.generic import View
 
 admin.autodiscover()
@@ -14,6 +14,6 @@ class TestClassRedirectView(PermissionRequiredMixin, View):
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
-    url(r'^accounts/login/', login, {'template_name': 'blank.html'}),
+    url(r'^accounts/login/', LoginView.as_view(template_name='blank.html')),
     url(r'^permission_required/', TestClassRedirectView.as_view()),
 ]

--- a/guardian/testapp/testsettings.py
+++ b/guardian/testapp/testsettings.py
@@ -2,7 +2,6 @@ import os
 import random
 import string
 import environ
-import django
 
 env = environ.Env()
 
@@ -29,16 +28,12 @@ AUTHENTICATION_BACKENDS = (
     'guardian.backends.ObjectPermissionBackend',
 )
 
-# this fixes warnings in django 1.10
 MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
 )
-
-if django.VERSION < (1, 10):
-    MIDDLEWARE_CLASSES = MIDDLEWARE
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
@@ -72,6 +67,3 @@ TEMPLATES = [
         },
     },
 ]
-
-if django.VERSION < (1, 8):
-    TEMPLATE_DIRS = TEMPLATES[0]['DIRS']

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -20,7 +20,6 @@ from guardian.ctypes import get_content_type
 from guardian.exceptions import NotUserNorGroup
 from itertools import chain
 
-import django
 import logging
 import os
 
@@ -102,12 +101,7 @@ def get_40x_or_None(request, perms, obj=None, login_url=None,
     if not has_permissions:
         if return_403:
             if guardian_settings.RENDER_403:
-                if django.VERSION >= (1, 10):
-                    response = render(request, guardian_settings.TEMPLATE_403)
-                else:
-                    response = render_to_response(
-                        guardian_settings.TEMPLATE_403, {},
-                        RequestContext(request))
+                response = render(request, guardian_settings.TEMPLATE_403)
                 response.status_code = 403
                 return response
             elif guardian_settings.RAISE_403:
@@ -115,12 +109,7 @@ def get_40x_or_None(request, perms, obj=None, login_url=None,
             return HttpResponseForbidden()
         if return_404:
             if guardian_settings.RENDER_404:
-                if django.VERSION >= (1, 10):
-                    response = render(request, guardian_settings.TEMPLATE_404)
-                else:
-                    response = render_to_response(
-                        guardian_settings.TEMPLATE_404, {},
-                        RequestContext(request))
+                response = render(request, guardian_settings.TEMPLATE_404)
                 response.status_code = 404
                 return response
             elif guardian_settings.RAISE_404:
@@ -164,17 +153,11 @@ def get_obj_perms_model(obj, base_cls, generic_cls):
         obj = obj.__class__
     ctype = get_content_type(obj)
 
-    if django.VERSION >= (1, 8):
-        fields = (f for f in obj._meta.get_fields()
-                  if (f.one_to_many or f.one_to_one) and f.auto_created)
-    else:
-        fields = obj._meta.get_all_related_objects()
+    fields = (f for f in obj._meta.get_fields()
+                if (f.one_to_many or f.one_to_one) and f.auto_created)
 
     for attr in fields:
-        if django.VERSION < (1, 8):
-            model = getattr(attr, 'model', None)
-        else:
-            model = getattr(attr, 'related_model', None)
+        model = getattr(attr, 'related_model', None)
         if (model and issubclass(model, base_cls) and
                 model is not generic_cls):
             # if model is generic one it would be returned anyway

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -7,14 +7,13 @@ they actual input parameters/output type may change in future releases.
 """
 from __future__ import unicode_literals
 from django.conf import settings
-from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth import REDIRECT_FIELD_NAME, get_user_model
 from django.contrib.auth.models import AnonymousUser, Group
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db.models import Model
 from django.http import HttpResponseForbidden, HttpResponseNotFound
 from django.shortcuts import render_to_response, render
 from django.template import RequestContext
-from guardian.compat import get_user_model
 from guardian.conf import settings as guardian_settings
 from guardian.ctypes import get_content_type
 from guardian.exceptions import NotUserNorGroup

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -14,7 +14,7 @@ from django.db.models import Model
 from django.http import HttpResponseForbidden, HttpResponseNotFound
 from django.shortcuts import render_to_response, render
 from django.template import RequestContext
-from guardian.compat import get_user_model, remote_model
+from guardian.compat import get_user_model
 from guardian.conf import settings as guardian_settings
 from guardian.ctypes import get_content_type
 from guardian.exceptions import NotUserNorGroup
@@ -182,7 +182,7 @@ def get_obj_perms_model(obj, base_cls, generic_cls):
                 # make sure that content_object's content_type is same as
                 # the one of given obj
                 fk = model._meta.get_field('content_object')
-                if ctype == get_content_type(remote_model(fk)):
+                if ctype == get_content_type(fk.remote_field.model):
                     return model
     return generic_cls
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=guardian.testapp.testsettings
+
+filterwarnings =
+    once::DeprecationWarning
+    once::PendingDeprecationWarning

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 downloadcache = {toxworkdir}/cache/
 envlist = # sort by django version, next by python version
-    {core,docs}-py{27,34,35,36}-django18,
-    {core,example,docs}-py{27,34,35,36}-django110,
     {core,example,docs}-py{27,34,35,36}-django111,
     {core,example,docs}-py{34,35,36}-django20,
 
@@ -32,7 +30,5 @@ deps =
     docs: sphinx
     docs: sphinx_rtd_theme
     docs: setuptools_scm
-    django18: django>=1.8,<1.9
-    django110: django>=1.10,<1.11
     django111: django>=1.11,<1.12
     django20: django>=2.0,<2.1


### PR DESCRIPTION
I tried to make small commits for easier reviews and exclusions of commits.  Feel free to squash them when merging the PR.

According to `Supported Versions` in https://www.djangoproject.com/download/, support for
- Django 1.9 ended in April 2017,
- Django 1.10 ended in December 2017,
- Django 1.8 ended at April 1, 2018.

The django maintainers suggested to drop support for Django < 1.11 in third party libraries with the release of Django 2.0 at December 2, 2017.  See https://docs.djangoproject.com/en/2.0/releases/2.0/#third-party-library-support-for-older-version-of-django