### PR TITLE
Add missing css class to the Grappelli template

### DIFF
--- a/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage.html
+++ b/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage.html
@@ -39,7 +39,7 @@
             <div class="l-2c-fluid l-d-4">
                 <div class="c-1"><label for="user-permissions" class="required">{% trans "User permissions" %}</label></div>
                 <div class="c-2">
-                    <table id="user-permissions" class="object-perms">
+                    <table id="user-permissions" class="grp-table object-perms">
                         <thead>
                             <tr>
                                 <th>{% trans "User" %}</th>
@@ -100,7 +100,7 @@
             <div class="l-2c-fluid l-d-4">
                 <div class="c-1"><label for="group-permissions" class="required">{% trans "Group permissions" %}</label></div>
                 <div class="c-2">
-                    <table id="group-permissions" class="object-perms">
+                    <table id="group-permissions" class="grp-table object-perms">
                         <thead>
                             <tr>
                                 <th>{% trans "Group" %}</th>


### PR DESCRIPTION
`grp-table` class is now required on HTML <table> with latest Grappelli versions