### PR TITLE
Allow for adding permission to multiple users or groups

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,3 +56,4 @@ Authors ordered by first contribution
 - Frank Wickström <frank@bambuser.com>
 - George Karakostas <gckarakostas@gmail.com>
 - Adam Dobrawy <guardian@jawnosc.tk>
+- Jeff Hackshaw <intrepidevio@gmail.com>

--- a/guardian/exceptions.py
+++ b/guardian/exceptions.py
@@ -23,3 +23,7 @@ class WrongAppError(GuardianError):
 
 class MixedContentTypeError(GuardianError):
     pass
+
+
+class MultipleIdentityAndObjectError(GuardianError):
+    pass

--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -78,6 +78,34 @@ class BaseObjectPermissionManager(models.Manager):
 
         return assigned_perms
 
+    def assign_perm_to_many(self, perm, users_or_groups, obj):
+        """
+        Bulk assigns given ``perm`` for the object ``obj`` to a set of users or a set of groups.
+        """
+        ctype = get_content_type(obj)
+        if not isinstance(perm, Permission):
+            permission = Permission.objects.get(content_type=ctype,
+                                                codename=perm)
+        else:
+            permission = perm
+
+        kwargs = {'permission': permission}
+        if self.is_generic():
+            kwargs['content_type'] = ctype
+            kwargs['object_pk'] = obj.pk
+        else:
+            kwargs['content_object'] = obj
+
+        to_add = []
+        field = self.user_or_group_field
+        for user in users_or_groups:
+            kwargs[field] = user
+            to_add.append(
+                self.model(**kwargs)
+            )
+
+        return self.model.objects.bulk_create(to_add)
+
     def assign(self, perm, user_or_group, obj):
         """ Depreciated function name left in for compatibility"""
         warnings.warn("UserObjectPermissionManager method 'assign' is being renamed to 'assign_perm'. Update your code accordingly as old name will be depreciated in 2.0 version.", DeprecationWarning)

--- a/guardian/testapp/tests/test_utils.py
+++ b/guardian/testapp/tests/test_utils.py
@@ -53,6 +53,26 @@ class GetIdentityTest(ObjectPermissionTestCase):
         self.assertRaises(NotUserNorGroup, get_identity, "User")
         self.assertRaises(NotUserNorGroup, get_identity, User)
 
+    def test_multiple_user_qs(self):
+        user, group = get_identity(User.objects.all())
+        self.assertIsInstance(user, models.QuerySet)
+        self.assertIsNone(group)
+
+    def test_multiple_user_list(self):
+        user, group = get_identity([self.user])
+        self.assertIsInstance(user, list)
+        self.assertIsNone(group)
+
+    def test_multiple_group_qs(self):
+        user, group = get_identity(Group.objects.all())
+        self.assertIsInstance(group, models.QuerySet)
+        self.assertIsNone(user)
+
+    def test_multiple_group_list(self):
+        user, group = get_identity([self.group])
+        self.assertIsInstance(group, list)
+        self.assertIsNone(user)
+
 
 @skipUnlessTestApp
 class GetUserObjPermsModelTest(TestCase):

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.models import AnonymousUser, Group
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
-from django.db.models import Model
+from django.db.models import Model, QuerySet
 from django.http import HttpResponseForbidden, HttpResponseNotFound
 from django.shortcuts import render_to_response, render
 from django.template import RequestContext
@@ -72,9 +72,23 @@ def get_identity(identity):
     if isinstance(identity, AnonymousUser):
         identity = get_anonymous_user()
 
+    # get identity from queryset model type
+    if isinstance(identity, QuerySet):
+        identity_model_type = identity.model
+        if identity_model_type == get_user_model():
+            return identity, None
+        elif identity_model_type == Group:
+            return None, identity
+
+    # get identity from first element in list
+    if isinstance(identity, list) and isinstance(identity[0], get_user_model()):
+        return identity, None
+    if isinstance(identity, list) and isinstance(identity[0], Group):
+        return None, identity
+
     if isinstance(identity, get_user_model()):
         return identity, None
-    elif isinstance(identity, Group):
+    if isinstance(identity, Group):
         return None, identity
 
     raise NotUserNorGroup("User/AnonymousUser or Group instance is required "


### PR DESCRIPTION

This allows for using the `assign_perm` shortcut to grant a set of users or groups permissions to an object in bulk.

```
article = Article.objects.get(pk=1)

user_queryset = User.objects.filter(some_attr=some_value).all()
assign_perm("change_article", user_queryset, article)

user_list = [user1, user2, user3, user4]
assign_perm("change_article", user_list, article)

group_queryset = Group.objects.filter(some_attr=some_value).all()
assign_perm("change_article", group_queryset, article)

group_list = [group1, group2, group3, group4]
assign_perm("change_article", group_list, article)
```