### PR TITLE
Fix silently failing tests

### DIFF
--- a/contrib/travis/install.sh
+++ b/contrib/travis/install.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -ev
+
 pip install -U pip six
 
 # Array of packages
@@ -20,3 +23,4 @@ if [[ $DATABASE_URL = mysql* ]]; then
 fi;
 echo "Install " ${PACKAGES[*]};
 pip install ${PACKAGES[*]};
+pip check

--- a/contrib/travis/install.sh
+++ b/contrib/travis/install.sh
@@ -22,5 +22,5 @@ if [[ $DATABASE_URL = mysql* ]]; then
     PACKAGES+=('mysqlclient==1.3.10');
 fi;
 echo "Install " ${PACKAGES[*]};
-pip install ${PACKAGES[*]};
+pip install --upgrade --upgrade-strategy=only-if-needed ${PACKAGES[*]};
 pip check


### PR DESCRIPTION
The first commit's intention is to prevent similar issues in the future by failing the test suite if this problem exists.  See https://travis-ci.org/django-guardian/django-guardian/builds/427284349

The second commit fixes the version conflict.

Fixes django-guardian/django-guardian#581