### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ notifications:
   irc: "irc.freenode.net#django-guardian"
 
 templates:
+  py37: &py37
+    python: 3.7
+    dist: xenial
+    sudo: required
+
   django111: &django111 DJANGO_VERSION=1.11
   django20: &django20 DJANGO_VERSION=2.0
   django21: &django21 DJANGO_VERSION=2.1
@@ -62,6 +67,16 @@ matrix:
     - { python: 3.6, env: [*djangomaster, *postgres]}
     - { python: 3.6, env: [*djangomaster, *mysql]}
     - { python: 3.6, env: [*djangomaster, *sqlite]}
+
+    - { <<: *py37, env: [*django20, *postgres], addons: {postgresql: "10"}}
+    - { <<: *py37, env: [*django20, *mysql], addons: {mariadb: "10.3"}}
+    - { <<: *py37, env: [*django20, *sqlite]}
+    - { <<: *py37, env: [*django21, *postgres], addons: {postgresql: "10"}}
+    - { <<: *py37, env: [*django21, *mysql], addons: {mariadb: "10.3"}}
+    - { <<: *py37, env: [*django21, *sqlite]}
+    - { <<: *py37, env: [*djangomaster, *postgres], addons: {postgresql: "10"}}
+    - { <<: *py37, env: [*djangomaster, *mysql], addons: {mariadb: "10.3"}}
+    - { <<: *py37, env: [*djangomaster, *sqlite]}
   allow_failures:
     - env: [*djangomaster, *postgres]
     - env: [*djangomaster, *mysql]

--- a/contrib/travis/install.sh
+++ b/contrib/travis/install.sh
@@ -7,19 +7,19 @@ pip install -U pip
 # Array of packages
 PACKAGES=('mock==1.0.1' 'pytest' 'pytest-django' 'pytest-cov' 'django-environ' 'setuptools_scm')
 # Install django master or version
-if [[ "$DJANGO_VERSION" == 'master' ]]; then 
+if [[ "$DJANGO_VERSION" == 'master' ]]; then
     PACKAGES+=('https://github.com/django/django/archive/master.tar.gz');
 else
     PACKAGES+=("Django==$DJANGO_VERSION");
 fi;
 
 # Install database drivers
-if [[ $DATABASE_URL = postgres* ]]; then 
-    PACKAGES+=('psycopg2==2.7.1');
+if [[ $DATABASE_URL = postgres* ]]; then
+    PACKAGES+=('psycopg2==2.7.5');
 fi;
 
 if [[ $DATABASE_URL = mysql* ]]; then
-    PACKAGES+=('mysqlclient==1.3.10');
+    PACKAGES+=('mysqlclient==1.3.13');
 fi;
 echo "Install " ${PACKAGES[*]};
 pip install --upgrade --upgrade-strategy=only-if-needed ${PACKAGES[*]};

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
                  'Programming Language :: Python :: 3.4',
                  'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
+                 'Programming Language :: Python :: 3.7',
                  ],
     test_suite='tests.main',
     cmdclass={'flakes': RunFlakesCommand},

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 downloadcache = {toxworkdir}/cache/
 envlist = # sort by django version, next by python version
     {core,example,docs}-py{27,34,35,36}-django111,
-    {core,example,docs}-py{34,35,36}-django20,
-    {core,example,docs}-py{35,36}-django21,
+    {core,example,docs}-py{34,35,36,py37}-django20,
+    {core,example,docs}-py{35,36,py37}-django21,
 
 [testenv]
 passenv = DATABASE_URL
@@ -12,6 +12,7 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 changedir =
     example: example_project
     docs: docs


### PR DESCRIPTION
It was a bit tricky to get Travis CI to cooperate.  `services` worked for MySQL, but not for PostgreSQL.  I went with `addons` in the end because it allows one to specify the version.

I'm not sure if tests should run against PostgreSQL 10 and MariaDB 10.3 or against the oldest versions (PostgreSQL [9.4](https://docs.djangoproject.com/en/2.1/releases/2.1/#dropped-support-for-postgresql-9-3) and MySQL [5.6](https://docs.djangoproject.com/en/2.1/releases/2.1/#dropped-support-for-mysql-5-5); not sure about MariaDB).

Anyways, it works without adjustments in the code itself. :)

Closes django-guardian/django-guardian#582