### PR TITLE
Updated changes for v1.5.0 release.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,7 @@
-Release 1.5.0 (Unreleased)
+Release 1.5.0 (Jan 31, 2019)
 ==========================
 
 * Updates for compatibility with latest Python and Django versions. 
-
 
 Release 1.4.9 (Jul 01, 2017)
 ============================

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+Release 1.5.0 (Unreleased)
+==========================
+
+* Updates for compatibility with latest Python and Django versions. 
+
+
 Release 1.4.9 (Jul 01, 2017)
 ============================
 


### PR DESCRIPTION
Should be sufficient to allow release to PyPI of changes on `master` which are needed for Django v2.2, which is in pre-release now. 

(Tests are already passing against Django `master`.)

Closes #600