### PR TITLE
Call `string.split` without kwargs for Python 2.7 compat

### DIFF
--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -82,7 +82,7 @@ class ObjectPermissionBackend(object):
             return False
 
         if '.' in perm:
-            app_label, _ = perm.split('.', maxsplit=1)
+            app_label, _ = perm.split('.', 1)
             if app_label != obj._meta.app_label:
                 # Check the content_type app_label when permission
                 # and obj app labels don't match.

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -74,7 +74,7 @@ class ObjectPermissionChecker(object):
         elif self.user and self.user.is_superuser:
             return True
         if '.' in perm:
-            _, perm = perm.split('.', maxsplit=1)
+            _, perm = perm.split('.', 1)
         return perm in self.get_perms(obj)
 
     def get_group_filters(self, obj):


### PR DESCRIPTION
Releasing version 1.5.1 with a fix for Python 2.7 support would be the polite thing to do.  This PR paves the way towards that.

Fixes django-guardian/django-guardian#602