### PR TITLE
Fix RemovedInDjango21Warning in authenticate signature

### DIFF
--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -53,7 +53,7 @@ class ObjectPermissionBackend(object):
     supports_anonymous_user = True
     supports_inactive_user = True
 
-    def authenticate(self, username, password):
+    def authenticate(self, request, username, password):
         return None
 
     def has_perm(self, user_obj, perm, obj=None):


### PR DESCRIPTION
Have been getting this warning when using the [django test client](https://docs.djangoproject.com/en/2.2/topics/testing/tools/#default-test-client) with guardian setup as an authentication backend. Specifically when calling `client.login(username, password)` with the `client` fixture in `pytest-django`.

Could this break backwards compatibility?

Edit: I see #604 will require a major version bump, so this could easily fit in there.