### PR TITLE
Use the correct DB in post_migration handler

### DIFF
--- a/guardian/management/__init__.py
+++ b/guardian/management/__init__.py
@@ -28,12 +28,12 @@ def create_anonymous_user(sender, **kwargs):
     User = get_user_model()
     try:
         lookup = {User.USERNAME_FIELD: guardian_settings.ANONYMOUS_USER_NAME}
-        User.objects.get(**lookup)
+        User.objects.using(kwargs['using']).get(**lookup)
     except User.DoesNotExist:
         retrieve_anonymous_function = import_string(
             guardian_settings.GET_INIT_ANONYMOUS_USER)
         user = retrieve_anonymous_function(User)
-        user.save()
+        user.save(using=kwargs['using'])
 
 # Only create an anonymous user if support is enabled.
 if guardian_settings.ANONYMOUS_USER_NAME is not None:

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -24,7 +24,7 @@ User = get_user_model()
 class CustomUserTests(TestCase):
 
     def test_create_anonymous_user(self):
-        create_anonymous_user(object())
+        create_anonymous_user(object(), using='default')
         self.assertEqual(1, User.objects.all().count())
         anonymous = User.objects.all()[0]
         self.assertEqual(anonymous.username, guardian_settings.ANONYMOUS_USER_NAME)

--- a/guardian/testapp/tests/test_management.py
+++ b/guardian/testapp/tests/test_management.py
@@ -22,11 +22,11 @@ class TestGetAnonymousUser(TestCase):
 
         anon = mocked_get_init_anon.return_value = mock.Mock()
 
-        create_anonymous_user('sender')
+        create_anonymous_user('sender', using='default')
 
         mocked_get_init_anon.assert_called_once_with(User)
 
-        anon.save.assert_called_once_with()
+        anon.save.assert_called_once_with(using='default')
 
     @mock.patch('guardian.management.guardian_settings')
     @override_settings(AUTH_USER_MODEL='testapp.CustomUsernameUser')
@@ -37,9 +37,9 @@ class TestGetAnonymousUser(TestCase):
         User = get_user_model()
 
         anon = mocked_get_init_anon.return_value = mock.Mock()
-        create_anonymous_user('sender')
+        create_anonymous_user('sender', using='default')
         mocked_get_init_anon.assert_called_once_with(User)
-        anon.save.assert_called_once_with()
+        anon.save.assert_called_once_with(using='default')
 
     def test_get_anonymous_user(self):
         anon = get_anonymous_user()


### PR DESCRIPTION
Django provides a keyword argument called `using` to the `post_migrate`
signal handler. This argument tells the handler which database was
migrated.

Previously, the `create_anonymous_user()` function would always try to
use the default database to create the anonymous user. This change uses
the `using` parameter to make sure we use the database that actually
underwent the migration.

Closes: django-guardian/django-guardian#630