### PR TITLE
Auto prefetching for vanilla usecases

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -153,3 +153,17 @@ polymorphic models and the regular model ``ContentType`` for non-polymorphic
 classes.
 
 Defaults to ``"guardian.ctypes.get_default_content_type"``.
+
+GUARDIAN_AUTO_PREFETCH
+-------------------------
+
+.. versionadded:: 2.x.x
+
+For vanilla deployments using standard ``ContentType`` interfaces and default
+``UserObjectPermission`` or ``GroupObjectPermission`` models, Guardian can automatically
+prefetch all User permissions for all object types. This can be useful when manual prefetching
+is not feasible due to a large number of model types resulting in O(n) queries. This setting may
+not be compatible with non-standard deployments, and should only be used when non-prefetched
+invocations would result in a large number of queries or when latency is particularly important.
+
+Defaults to ``False``.

--- a/guardian/__init__.py
+++ b/guardian/__init__.py
@@ -27,3 +27,4 @@ def monkey_patch_user():
             lambda self, perm, obj: UserObjectPermission.objects.assign_perm(perm, self, obj))
     setattr(User, 'del_obj_perm',
             lambda self, perm, obj: UserObjectPermission.objects.remove_perm(perm, self, obj))
+    setattr(User, 'evict_obj_perm_cache', lambda self: delattr(self, '_guardian_perms_cache'))

--- a/guardian/conf/settings.py
+++ b/guardian/conf/settings.py
@@ -24,6 +24,8 @@ MONKEY_PATCH = getattr(settings, 'GUARDIAN_MONKEY_PATCH', True)
 
 GET_CONTENT_TYPE = getattr(settings, 'GUARDIAN_GET_CONTENT_TYPE', 'guardian.ctypes.get_default_content_type')
 
+AUTO_PREFETCH = getattr(settings, 'GUARDIAN_AUTO_PREFETCH', False)
+
 
 def check_configuration():
     if RENDER_403 and RAISE_403:

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -153,7 +153,8 @@ class ObjectPermissionChecker:
         ctype = get_content_type(obj)
         key = self.get_local_cache_key(obj)
         if key not in self._obj_perms_cache:
-            if guardian_settings.AUTO_PREFETCH:
+            # For now we only enforce when a User is passed in
+            if self.user and guardian_settings.AUTO_PREFETCH:
                 return []
             if self.user and self.user.is_superuser:
                 perms = list(chain(*Permission.objects
@@ -279,6 +280,7 @@ class ObjectPermissionChecker:
         self.user._guardian_perms_cache = cache
 
     def _prefetch_cache(self):
-        if self.user and not hasattr(self.user, '_guardian_perms_cache'):
-            self._init_user_cache()
-        self._obj_perms_cache = self.user._guardian_perms_cache
+        if self.user:
+            if not hasattr(self.user, '_guardian_perms_cache'):
+                self._init_user_cache()
+            self._obj_perms_cache = self.user._guardian_perms_cache


### PR DESCRIPTION
I threw this together for our own internal use which involves iterating over many various object types through many libraries and interfaces. It simply wasn't feasible to do explicit prefetching the way that django-guardian currently allows. This expects a pretty vanilla setup so definitely not for everyone, but would be nice to have some out-of-the-box functionality that does this. A query-per-check architecture is too onerous for some people.