### PR TITLE
Better cache eviction and testing

### DIFF
--- a/guardian/__init__.py
+++ b/guardian/__init__.py
@@ -18,7 +18,7 @@ def get_version():
 
 def monkey_patch_user():
     from django.contrib.auth import get_user_model
-    from .utils import get_anonymous_user
+    from .utils import get_anonymous_user, evict_obj_perms_cache
     from .models import UserObjectPermission
     User = get_user_model()
     # Prototype User and Group methods
@@ -27,4 +27,4 @@ def monkey_patch_user():
             lambda self, perm, obj: UserObjectPermission.objects.assign_perm(perm, self, obj))
     setattr(User, 'del_obj_perm',
             lambda self, perm, obj: UserObjectPermission.objects.remove_perm(perm, self, obj))
-    setattr(User, 'evict_obj_perm_cache', lambda self: delattr(self, '_guardian_perms_cache'))
+    setattr(User, 'evict_obj_perms_cache', evict_obj_perms_cache)

--- a/guardian/testapp/tests/test_other.py
+++ b/guardian/testapp/tests/test_other.py
@@ -286,6 +286,7 @@ class TestMonkeyPatch(TestCase):
         self.assertFalse(getattr(CustomUserTestClass, 'get_anonymous', False))
         self.assertFalse(getattr(CustomUserTestClass, 'add_obj_perm', False))
         self.assertFalse(getattr(CustomUserTestClass, 'del_obj_perm', False))
+        self.assertFalse(getattr(CustomUserTestClass, 'evict_obj_perms_cache', False))
 
         # Monkey Patch
         guardian.monkey_patch_user()
@@ -293,3 +294,7 @@ class TestMonkeyPatch(TestCase):
         self.assertTrue(getattr(CustomUserTestClass, 'get_anonymous', False))
         self.assertTrue(getattr(CustomUserTestClass, 'add_obj_perm', False))
         self.assertTrue(getattr(CustomUserTestClass, 'del_obj_perm', False))
+        self.assertTrue(getattr(CustomUserTestClass, 'evict_obj_perms_cache', False))
+
+        user = CustomUserTestClass()
+        self.assertFalse(user.evict_obj_perms_cache())

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -196,3 +196,10 @@ def get_group_obj_perms_model(obj):
     from guardian.models import GroupObjectPermissionBase
     from guardian.models import GroupObjectPermission
     return get_obj_perms_model(obj, GroupObjectPermissionBase, GroupObjectPermission)
+
+
+def evict_obj_perms_cache(obj):
+    if hasattr(obj, '_guardian_perms_cache'):
+        delattr(obj, '_guardian_perms_cache')
+        return True
+    return False


### PR DESCRIPTION
Original auto prefetch PR lacked tests for cache eviction and refetching. The `evict_obj_perms_cache()` call now also returns False if the cache is not evicted (i.e. doesn't exist), and True if the cache was evicted.