### PR TITLE
Fix cache reuse and add tests that invoke backend

### DIFF
--- a/guardian/core.py
+++ b/guardian/core.py
@@ -294,4 +294,6 @@ class ObjectPermissionChecker:
 
         if not hasattr(obj, '_guardian_perms_cache'):
             obj, cache = self._init_obj_prefetch_cache(obj, *querysets)
-            self._obj_perms_cache = cache
+        else:
+            cache = obj._guardian_perms_cache
+        self._obj_perms_cache = cache

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -486,21 +486,25 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
 
             # Checking shouldn't spawn any queries
             self.assertTrue(checker.has_perm("change_group", self.group))
+            self.assertTrue(user.has_perm("change_group", self.group))
             self.assertEqual(len(connection.queries), query_count)
 
             # Checking for other permission but for Group object again
             # shouldn't spawn any query too
             self.assertFalse(checker.has_perm("delete_group", self.group))
+            self.assertFalse(user.has_perm("delete_group", self.group))
             self.assertEqual(len(connection.queries), query_count)
 
             # Checking for same model but other instance shouldn't spawn any queries
             self.assertTrue(checker.has_perm("change_group", group1))
+            self.assertTrue(user.has_perm("change_group", group1))
             self.assertEqual(len(connection.queries), query_count)
 
             # Checking for same model but other instance shouldn't spawn any queries
             # Even though User doesn't have perms on Group2, we still should
             #  not hit DB
             self.assertFalse(checker.has_perm("change_group", group2))
+            self.assertFalse(user.has_perm("change_group", group2))
             self.assertEqual(len(connection.queries), query_count)
 
             # Evict cache and verify that reloaded perms have changed
@@ -511,6 +515,7 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
             # New checker object so that we reload perms from db
             checker = ObjectPermissionChecker(user)
             self.assertTrue(checker.has_perm("delete_group", self.group))
+            self.assertTrue(user.has_perm("delete_group", self.group))
             # Two more queries should have been executed
             self.assertEqual(len(connection.queries), query_count + 2)
 
@@ -545,15 +550,18 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
 
             # Checking shouldn't spawn any queries
             self.assertTrue(checker.has_perm("change_group", self.group))
+            self.assertTrue(user.has_perm("change_group", self.group))
             self.assertEqual(len(connection.queries), query_count)
 
             # Checking for other permission but for Group object again
             # shouldn't spawn any query too
             self.assertTrue(checker.has_perm("delete_group", self.group))
+            self.assertTrue(user.has_perm("delete_group", self.group))
             self.assertEqual(len(connection.queries), query_count)
 
             # Checking for same model but other instance shouldn't spawn any queries
             self.assertTrue(checker.has_perm("change_group", group1))
+            self.assertTrue(user.has_perm("change_group", group1))
             self.assertEqual(len(connection.queries), query_count)
         finally:
             settings.DEBUG = False


### PR DESCRIPTION
Bit of an emergency fix here, my fault. Our internal branch was slightly behind and thus we didn't catch until now. The cache isn't actually reused if called from the user object which invokes the django backend. This will cause the cache to return false for all subsequent calls. It wasn't caught by the core tests which skip calls that invoke the django backend entirely, and solely rely on the checker object.