### PR TITLE
Improve performance of get_objects_for_user, removing sets

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -617,7 +617,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
 
     is_cast_integer = _is_cast_integer_pk(queryset)
 
-    field_pk = user_field[0]
+    field_pk = user_fields[0]
     values = user_obj_perms_queryset
     if is_cast_integer:
         values = values.annotate(
@@ -628,7 +628,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
     values = values.values_list(field_pk, flat=True)
     q = Q(pk__in=values)
     if use_groups:
-        field_pk = group_field[0]
+        field_pk = group_fields[0]
         values = groups_obj_perms_queryset
         if is_cast_integer:
             values = values.annotate(

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -621,7 +621,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
     values = user_obj_perms_queryset
     if is_cast_integer:
         values = values.annotate(
-            obj_pk=Cast(field_pk, IntegerField())
+            obj_pk=Cast(field_pk, BigIntegerField())
         )
         field_pk = 'obj_pk'
 
@@ -632,7 +632,7 @@ def get_objects_for_user(user, perms, klass=None, use_groups=True, any_perm=Fals
         values = groups_obj_perms_queryset
         if is_cast_integer:
             values = values.annotate(
-                obj_pk=Cast(field_pk, IntegerField())
+                obj_pk=Cast(field_pk, BigIntegerField())
             )
             field_pk = 'obj_pk'
         values = values.values_list(field_pk, flat=True)
@@ -788,7 +788,7 @@ def get_objects_for_group(group, perms, klass=None, any_perm=False, accept_globa
 
     if is_cast_integer:
         values = values.annotate(
-            obj_pk=Cast(field_pk, IntegerField())
+            obj_pk=Cast(field_pk, BigIntegerField())
         )
         field_pk = 'obj_pk'
 

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -1182,7 +1182,7 @@ class GetObjectsForGroup(TestCase):
                                         ['contenttypes.change_contenttype',
                                          'contenttypes.delete_contenttype'], any_perm=True)
         self.assertTrue(isinstance(objects, QuerySet))
-        self.assertEqual([obj for obj in objects.order_by('app_label')],
+        self.assertEqual([obj for obj in objects.order_by('app_label', 'id')],
                          [self.obj1, self.obj3])
 
     def test_results_for_different_groups_are_correct(self):


### PR DESCRIPTION
Hi,

Since django 1.8 it is not necessary to use a "set" or a list it can be directly replaced inside the id__in parameter, the queryset will always receive the same type of content type and the validation is not necessary.

