### PR TITLE
Remove setup_requires from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
     name='django-guardian',
     version=version,
     python_requires='>=3.5',
-    setup_requires=['pytest-runner', ],
     url='http://github.com/django-guardian/django-guardian',
     author='Lukasz Balcerzak',
     author_email='lukaszbalcerzak@gmail.com',


### PR DESCRIPTION
Using `setup_requires` requires that `pip` has no way of controlling where these dependencies are located.

See

- https://github.com/pytest-dev/pytest-xdist/issues/136
- https://pip.pypa.io/en/stable/reference/pip_install/#controlling-setup-requires

This makes it difficult/impossible to bundle this library for offline installs, for example, using [`pip download`](https://pip.pypa.io/en/stable/reference/pip_download/).

Also, as far as I can tell `pytest-runner` isn't really used in the project and likely `tox` should be used to invoke `pytest` for testing instead.