### PR TITLE
Add requirements (specifically, Django >= 2.1) to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     include_package_data=True,
     license='BSD',
-    install_requires=[],
+    install_requires=["Django>=2.1"],
     tests_require=['mock', 'django-environ', 'pytest', 'pytest-django'],
     classifiers=['Development Status :: 5 - Production/Stable',
                  'Environment :: Web Environment',


### PR DESCRIPTION
[Python's official documentation](https://packaging.python.org/discussions/install-requires-vs-requirements/) describes that packages should declare their installation dependencies in setup.py in order to play nicely with setuptools.

I enjoy using `django-guardian` in one of my projects, but I currently have to handle it differently than all of my other dependencies because it doesn't use `install_requires`.

I'm not sure whether `bumpversion` needs to be in `install_requires`. Let me know what you think.

Thanks!