### PR TITLE
Replace deprecated admin_static with static

### DIFF
--- a/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage.html
+++ b/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage.html
@@ -1,7 +1,7 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
 {% load guardian_tags %}
-{% load admin_static %}
+{% load static %}
 {% load admin_urls %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
`admin_static` was [deprecated](https://docs.djangoproject.com/en/dev/releases/2.1/#features-deprecated-in-2-1) in Django 2.1 and will be [removed](https://docs.djangoproject.com/en/dev/releases/3.0/#features-removed-in-3-0) in 3.0