### PR TITLE
Fix circular dependency by deferring get obj perms model call

### DIFF
--- a/guardian/models/__init__.py
+++ b/guardian/models/__init__.py
@@ -3,8 +3,10 @@ from .models import (
     BaseGenericObjectPermission,
     UserObjectPermissionBase,
     UserObjectPermissionAbstract,
+    UserObjectPermission,
     GroupObjectPermissionBase,
     GroupObjectPermissionAbstract,
+    GroupObjectPermission,
     Permission,
     Group
 )

--- a/guardian/models/__init__.py
+++ b/guardian/models/__init__.py
@@ -9,13 +9,6 @@ from .models import (
     Group
 )
 
-# Must import after .models
-# When .models is loaded, default generic object permissions are created
-# The following statements may redirect external references to custom
-# generic object permission models
-from guardian.utils import get_user_obj_perms_model, get_group_obj_perms_model
-UserObjectPermission = get_user_obj_perms_model()
-GroupObjectPermission = get_group_obj_perms_model()
 
 __all__ = [
     'BaseObjectPermission',


### PR DESCRIPTION
Defer get obj perms model call until runtime to avoid potential circular dependencies.

For example, in user code using custom generic object permissions do this:
```
from guardian.utils import get_user_obj_perms_model, get_group_obj_perms_model
UserObjectPermission = get_user_obj_perms_model()
GroupObjectPermission = get_group_obj_perms_model()
```
not of this:
```
from guardian.models import UserObjectPermission, GroupObjectPermission
```

1. direct foreign key compatibility already requires the use of `get_user_obj_perms_model()` and `get_user_obj_perms_model()`
2. custom generic object permissions just requires the same use `get_user_obj_perms_model()` and `get_user_obj_perms_model()` as direct foreign key object permissions

