### PR TITLE
Remove use of deprecated function.

### DIFF
--- a/guardian/models/models.py
+++ b/guardian/models/models.py
@@ -3,7 +3,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from guardian.compat import user_model_label
 from guardian.ctypes import get_content_type
 from guardian.managers import GroupObjectPermissionManager, UserObjectPermissionManager


### PR DESCRIPTION
`django.utils.translation.ugettext_lazy()` is deprecated in favor of` django.utils.translation.gettext_lazy()` and will be removed in Django 4.0