### PR TITLE
Modify 'assign_perm' shortcut to treat lists as a queryset

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,3 +59,4 @@ Authors ordered by first contribution
 - Jeff Hackshaw <intrepidevio@gmail.com>
 - Chase Bennett <ch@se.gd>
 - Jonny Arnold <jonny.arnold89@gmail.com>
+- Davis Raymond Muro <davisraymondmuro@gmail.com>

--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -54,8 +54,11 @@ class BaseObjectPermissionManager(models.Manager):
         Bulk assigns permissions with given ``perm`` for an objects in ``queryset`` and
         ``user_or_group``.
         """
+        if isinstance(queryset, list):
+            ctype = get_content_type(queryset[0])
+        else:
+            ctype = get_content_type(queryset.model)
 
-        ctype = get_content_type(queryset.model)
         if not isinstance(perm, Permission):
             permission = Permission.objects.get(content_type=ctype, codename=perm)
         else:

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -43,8 +43,8 @@ def assign_perm(perm, user_or_group, obj=None):
       ``guardian.exceptions.NotUserNorGroup`` exception
 
     :param obj: persisted Django's ``Model`` instance or QuerySet of Django
-      ``Model`` instances or ``None`` if assigning global permission.
-      Default is ``None``.
+      ``Model`` instances or list of Django ``Model`` instances or ``None``
+      if assigning global permission. Default is ``None``.
 
     We can assign permission for ``Model`` instance for specific user:
 
@@ -100,14 +100,16 @@ def assign_perm(perm, user_or_group, obj=None):
         if '.' in perm:
             app_label, perm = perm.split(".", 1)
 
-    if isinstance(obj, QuerySet):
+    if isinstance(obj, (QuerySet, list)):
         if isinstance(user_or_group, (QuerySet, list)):
             raise MultipleIdentityAndObjectError("Only bulk operations on either users/groups OR objects supported")
         if user:
-            model = get_user_obj_perms_model(obj.model)
+            model = get_user_obj_perms_model(
+                    obj[0] if isinstance(obj, list) else obj.model)
             return model.objects.bulk_assign_perm(perm, user, obj)
         if group:
-            model = get_group_obj_perms_model(obj.model)
+            model = get_group_obj_perms_model(
+                    obj[0] if isinstance(obj, list) else obj.model)
             return model.objects.bulk_assign_perm(perm, group, obj)
 
     if isinstance(user_or_group, (QuerySet, list)):

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -41,6 +41,7 @@ class ObjectPermissionTestCase(TestCase):
             model='bar', app_label='fake-for-guardian-tests')
         self.ctype_qset = ContentType.objects.filter(model='bar',
                                                      app_label='fake-for-guardian-tests')
+        self.ctype_list = [self.ctype_qset.first()]
         self.anonymous_user = User.objects.get(
             username=guardian_settings.ANONYMOUS_USER_NAME)
 

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -134,6 +134,34 @@ class AssignPermTest(ObjectPermissionTestCase):
             self.assertEqual(len(warns), 1)
             self.assertTrue(isinstance(warns[0].message, DeprecationWarning))
 
+    def test_user_assign_perm_list(self):
+        """
+        Test that one is able to assign permissions for a list of objects
+        to a user
+        """
+        assign_perm("add_contenttype", self.user, self.ctype_list)
+        assign_perm("change_contenttype", self.group, self.ctype_list)
+        assign_perm(self.get_permission("delete_contenttype"), self.user, self.ctype_list)
+        for obj in self.ctype_list:
+            self.assertTrue(self.user.has_perm("add_contenttype", obj))
+            self.assertTrue(self.user.has_perm("change_contenttype", obj))
+            self.assertTrue(self.user.has_perm("delete_contenttype", obj))
+
+    def test_group_assign_perm_list(self):
+        """
+        Test that one is able to assign permissions for a list of
+        objects to a group
+        """
+        assign_perm("add_contenttype", self.group, self.ctype_list)
+        assign_perm("change_contenttype", self.group, self.ctype_list)
+        assign_perm(self.get_permission("delete_contenttype"), self.group, self.ctype_list)
+
+        check = ObjectPermissionChecker(self.group)
+        for obj in self.ctype_list:
+            self.assertTrue(check.has_perm("add_contenttype", obj))
+            self.assertTrue(check.has_perm("change_contenttype", obj))
+            self.assertTrue(check.has_perm("delete_contenttype", obj)) 
+
 
 class MultipleIdentitiesOperationsTest(ObjectPermissionTestCase):
     """


### PR DESCRIPTION
## Changes Implemented

- Modified the `bulk_assign_perm` function within the`BaseObjectPermissionManager` class to handle a list of objects
- Modified the `assign_perm` shortcut function to handle a list of objects
- Added @DavisRayM to the `AUTHORS` file

Fixes #610 