### PR TITLE
Fix broken Django docs link

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -114,7 +114,7 @@ environment.
 
 Defaults to ``"AnonymousUser"``.
 
-.. seealso:: https://docs.djangoproject.com/en/2.1/topics/auth/customizing/#substituting-a-custom-user-model
+.. seealso:: https://docs.djangoproject.com/en/stable/topics/auth/customizing/#substituting-a-custom-user-model
 
 
 .. setting:: GUARDIAN_GET_INIT_ANONYMOUS_USER

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -41,6 +41,6 @@ For instance, `django-authority`_ or
 .. _issue-tracker: http://github.com/lukaszb/django-guardian
 .. _grappelli: https://github.com/sehmaschine/django-grappelli
 
-.. [1] See http://docs.djangoproject.com/en/1.2/topics/auth/#handling-object-permissions
+.. [1] See https://docs.djangoproject.com/en/stable/topics/auth/customizing/#handling-object-permissions
    for more detail.
 

--- a/docs/userguide/assign.rst
+++ b/docs/userguide/assign.rst
@@ -57,7 +57,7 @@ our *assign_task* permission would be added to default set of permissions.
    add ``default_permissions = ('add', 'change', 'delete')`` to ``Meta``.
 
 There is nothing new here since creation of permissions is 
-`handled by django <http://docs.djangoproject.com/en/2.2/topics/auth/#id1>`_.
+`handled by django <https://docs.djangoproject.com/en/stable/topics/auth/>`_.
 Now we can move to :ref:`assigning object permissions <assign-obj-perms>`.
 
 .. _assign-obj-perms:


### PR DESCRIPTION
Also update other links to point to latest stable docs rather than insecure versions of Django.