### PR TITLE
Run migrations check only if required version of django is installed

### DIFF
--- a/contrib/travis/test.sh
+++ b/contrib/travis/test.sh
@@ -11,5 +11,11 @@ py.test --cov=guardian
 # Test example_project
 pip install .;
 cd example_project;
-python -Wa manage.py makemigrations --check --dry-run;
+EXAMPLE_PROJECTS_DJANGO_VERSION=$(grep -i "django[^-]" requirements.txt | cut -d "=" -f 2)
+if [ "${DJANGO_VERSION:0:3}" = "${EXAMPLE_PROJECTS_DJANGO_VERSION:0:3}" ]; then
+    python -Wa manage.py makemigrations --check --dry-run;
+elif [ -z "${EXAMPLE_PROJECTS_DJANGO_VERSION}" ]; then
+    echo "Could not determine which version of Django the example project supports."
+    exit 1
+fi;
 python -Wa manage.py test;


### PR DESCRIPTION
Django master changed the `max_length` of `AbstractUser`'s `first_name`.  As a result the tests against django-master are failing.  If we update the migrations, the tests will in combination with all stable releases of django.