### PR TITLE
Update link to current django-authority repository

### DIFF
--- a/docs/userguide/check.rst
+++ b/docs/userguide/check.rst
@@ -185,5 +185,5 @@ get_obj_perms
 .. autofunction:: guardian.templatetags.guardian_tags.get_obj_perms
    :noindex:
 
-.. _django-authority: http://bitbucket.org/jezdez/django-authority/
+.. _django-authority: https://github.com/jazzband/django-authority
 


### PR DESCRIPTION
Right now there is chain of redirection:

http://bitbucket.org/jezdez/django-authority/ -> https://github.com/jezdez/django-authority/ -> https://github.com/jazzband/django-authority