### PR TITLE
Use chain.from_iterable in core.py

### DIFF
--- a/guardian/core.py
+++ b/guardian/core.py
@@ -158,9 +158,7 @@ class ObjectPermissionChecker:
                 return []
             if self.user and self.user.is_superuser:
                 perms = list(
-                    chain.from_iterable(
-                        Permission.objects.filter(content_type=ctype).values_list("codename")
-                    )
+                    Permission.objects.filter(content_type=ctype).values_list("codename", flat=True)
                 )
             elif self.user:
                 # Query user and group permissions separately and then combine
@@ -195,9 +193,7 @@ class ObjectPermissionChecker:
 
         if self.user and self.user.is_superuser:
             perms = list(
-                chain.from_iterable(
-                    Permission.objects.filter(content_type=ctype).values_list("codename")
-                )
+                Permission.objects.filter(content_type=ctype).values_list("codename", flat=True)
             )
 
             for pk in pks:

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -157,9 +157,11 @@ class ObjectPermissionChecker:
             if guardian_settings.AUTO_PREFETCH:
                 return []
             if self.user and self.user.is_superuser:
-                perms = list(chain(*Permission.objects
-                                   .filter(content_type=ctype)
-                                   .values_list("codename")))
+                perms = list(
+                    chain.from_iterable(
+                        Permission.objects.filter(content_type=ctype).values_list("codename")
+                    )
+                )
             elif self.user:
                 # Query user and group permissions separately and then combine
                 # the results to avoid a slow query
@@ -192,10 +194,11 @@ class ObjectPermissionChecker:
         pks, model, ctype = _get_pks_model_and_ctype(objects)
 
         if self.user and self.user.is_superuser:
-            perms = list(chain(
-                *Permission.objects
-                .filter(content_type=ctype)
-                .values_list("codename")))
+            perms = list(
+                chain.from_iterable(
+                    Permission.objects.filter(content_type=ctype).values_list("codename")
+                )
+            )
 
             for pk in pks:
                 key = (ctype.id, force_str(pk))
@@ -245,9 +248,7 @@ class ObjectPermissionChecker:
             group_perms_qs = group_model.objects.filter(**group_filters).select_related('permission')
             perms = chain(user_perms_qs, group_perms_qs)
         else:
-            perms = chain(
-                *(group_model.objects.filter(**group_filters).select_related('permission'),)
-            )
+            perms = group_model.objects.filter(**group_filters).select_related('permission')
 
         # initialize entry in '_obj_perms_cache' for all prefetched objects
         for obj in objects:


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.