### PR TITLE
Fix function reference in docs: userguide remove section

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,3 +61,4 @@ Authors ordered by first contribution
 - Jonny Arnold <jonny.arnold89@gmail.com>
 - Davis Raymond Muro <davisraymondmuro@gmail.com>
 - Richard de Wit <henk.exe@gmail.com>
+- Pedro Rojas Gavidia <pedrorojas.gavidia@gmail.com> @pedrorojasg

--- a/docs/userguide/remove.rst
+++ b/docs/userguide/remove.rst
@@ -4,7 +4,7 @@ Remove object permissions
 =========================
 
 Removing object permissions is as easy as assigning them. Just instead of
-:func:`guardian.shortcuts.assign` we would use
+:func:`guardian.shortcuts.assign_perm` we would use
 :func:`guardian.shortcuts.remove_perm` function (it accepts same arguments).
 
 Example


### PR DESCRIPTION
Greetings, I propose to update the "assign" reference to "assign_perm".
To be consistent with the new version of the function and the rest of the docs that directly reference assign_perm.