### PR TITLE
Fixed headers test for Django 3.2

### DIFF
--- a/guardian/testapp/tests/test_decorators.py
+++ b/guardian/testapp/tests/test_decorators.py
@@ -1,3 +1,4 @@
+import django
 from django.conf import global_settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, AnonymousUser
@@ -383,8 +384,12 @@ class PermissionRequiredTest(TestDataMixin, TestCase):
             pass
         response = dummy_view(request, project_name='foobar')
         self.assertTrue(isinstance(response, HttpResponseRedirect))
-        self.assertTrue(response._headers['location'][1].startswith(
-            '/foobar/'))
+        if django.VERSION >= (3, 2):
+            self.assertTrue(response.headers['location'].startswith(
+                '/foobar/'))
+        else:
+            self.assertTrue(response._headers['location'][1].startswith(
+                '/foobar/'))
 
     @override_settings(LOGIN_URL='django.contrib.auth.views.login')
     def test_redirection_class(self):


### PR DESCRIPTION
The tests are currently [failing](https://travis-ci.org/github/django-guardian/django-guardian/jobs/728474687) against Django master due to the introduction of the new headers interface. This PR fixes the test. 

The response.headers interface is added in Django 3.2
https://github.com/django/django/commit/dcb69043d0de45bb55998fc418d93c28bc7689ae