### PR TITLE
added message for permission denied exceptions

### DIFF
--- a/guardian/mixins.py
+++ b/guardian/mixins.py
@@ -115,6 +115,12 @@ class PermissionRequiredMixin:
         `permission_required` - the permission to check of form "<app_label>.<permission codename>"
                                 i.e. 'polls.can_vote' for a permission on a model in the polls application.
 
+
+    ``PermissionRequiredMixin.permission_denied_message``
+
+        *Default*: ``None``. A string to pass to the ``PermisssionDenied`` exception.
+            Will be available in the 403 template context as ``exception``.
+
     ``PermissionRequiredMixin.accept_global_perms``
 
         *Default*: ``False``,  If accept_global_perms would be set to True, then
@@ -138,6 +144,7 @@ class PermissionRequiredMixin:
     return_403 = False
     return_404 = False
     raise_exception = False
+    permission_denied_message = None
     accept_global_perms = False
     any_perm = False
 
@@ -159,6 +166,16 @@ class PermissionRequiredMixin:
                                        "'<app_label>.<permission codename>' but is set to '%s' instead"
                                        % self.permission_required)
         return perms
+
+    def get_permission_denied_message(self):
+        """
+        Returns the message to be passed to the ``PermissionDenied`` exception. By default,
+        it returns the value from the ``permission_denied_message`` attribute.
+        """
+        message = ""
+        if isinstance(self.permission_denied_message, str):
+            message = self.permission_denied_message
+        return message
 
     def get_permission_object(self):
         if hasattr(self, 'permission_object'):
@@ -185,11 +202,12 @@ class PermissionRequiredMixin:
                                     return_404=self.return_404,
                                     accept_global_perms=self.accept_global_perms,
                                     any_perm=self.any_perm,
+                                    permission_denied_message=self.get_permission_denied_message(),
                                     )
         if forbidden:
             self.on_permission_check_fail(request, forbidden, obj=obj)
         if forbidden and self.raise_exception:
-            raise PermissionDenied()
+            raise PermissionDenied(self.get_permission_denied_message())
         return forbidden
 
     def on_permission_check_fail(self, request, response, obj=None):

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -94,7 +94,7 @@ def get_identity(identity):
 def get_40x_or_None(request, perms, obj=None, login_url=None,
                     redirect_field_name=None, return_403=False,
                     return_404=False, accept_global_perms=False,
-                    any_perm=False):
+                    any_perm=False, permission_denied_message=""):
     login_url = login_url or settings.LOGIN_URL
     redirect_field_name = redirect_field_name or REDIRECT_FIELD_NAME
 
@@ -121,7 +121,7 @@ def get_40x_or_None(request, perms, obj=None, login_url=None,
                 response.status_code = 403
                 return response
             elif guardian_settings.RAISE_403:
-                raise PermissionDenied
+                raise PermissionDenied(permission_denied_message)
             return HttpResponseForbidden()
         if return_404:
             if guardian_settings.RENDER_404:


### PR DESCRIPTION
I found myself wanting to pass a string to the `PermissionDenied` exceptions to that I could display more information to the user on the 403 page.

This PR adds an attribute `permission_denied_message` and an overridable method `get_permission_denied_message` to the PermissionRequiredMixin which can be configured with a message string that is passed to the PermissionDenied exception. By default, Django will then add the string representation of the `PermissionDenied` exception to the template context as `exception`.

If `permission_denied_message` is undefined, an empty string is passed to `PermissionDenied`.

Here are a couple of examples

1. Simple message.

If the current user does not have the `app_label.view_secretmodel` permission, they will be served the 403 page that contains the message "You do not have access to the request secret object.".

```python
# models.py
from django.db import models
from django.contrib.auth.models import User

class SecretModel(models.Model):
    name = models.CharField(max_length=30)
    owner = models.ForeignKey(User, on_delete=models.CASCADE)
```

```python
# views.py
from django.views.generic import DetailView
from guardian.mixins import PermissionRequiredMixin
from app_label.models import SecretModel

class SecretObjectDetail(PermissionRequiredMixin, DetailView):
    model = SecretModel
    permission_required = "app_label.view_secretmodel"
    raise_exception = True
    permission_denied_message = "You do not have access to the requested secret object."
```

```html
<!-- 403.html -->
{% extends "base.html" %}
{% block content %}
<div class="container-fluid">
  <div class="alert alert-danger" role="alert">
    <h3 class="alert-heading">Permission Denied</h3>
    {{ exception|default:"You do not have permission to view this content." }}
  </div>
</div>
{% endblock content %}
```

2. More detailed message.

`models.py` and `403.html` as above.

```python
# views.py
from django.views.generic import DetailView
from guardian.mixins import PermissionRequiredMixin
from app_label.models import SecretModel

class SecretModelDetail(PermissionRequiredMixin, DetailView):
    model = SecretModel
    permission_required = "app_label.view_secretmodel"
    raise_exception = True

    def get_permission_denied_message(self):
        obj = self.get_object()
        return (
            f"You do not have permission to view the secret object '{obj.name}'. "
            f"Please ask the owner, {obj.owner.username}, to grant you permission."
        )
```