### PR TITLE
Fixed default_app_config deprecation

### DIFF
--- a/guardian/__init__.py
+++ b/guardian/__init__.py
@@ -2,8 +2,10 @@
 Implementation of per object permissions for Django.
 """
 from . import checks
+import django
 
-default_app_config = 'guardian.apps.GuardianConfig'
+if django.VERSION < (3, 2):
+    default_app_config = 'guardian.apps.GuardianConfig'
 
 # PEP 396: The __version__ attribute's value SHOULD be a string.
 __version__ = '2.3.0'


### PR DESCRIPTION
Django 3.2 automatically detects `AppConfig` and therefore this setting is no longer required.  Here is the warning in the CI and the release notes. 

https://docs.djangoproject.com/en/dev/releases/3.2/#automatic-appconfig-discovery

https://travis-ci.org/github/django-guardian/django-guardian/jobs/735548344#L427