### PR TITLE
Added djangomaster to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = # sort by django version, next by python version
     {core,example,docs}-py{35,36,37,38}-django22,
     {core,example,docs}-py{36,37,38}-django30,
     {core,example,docs}-py{36,37,38,39}-django31,
+    {core,example,docs}-py{36,37,38,39}-djangomaster,
 
 [testenv]
 passenv = DATABASE_URL
@@ -20,6 +21,7 @@ commands =
     django22: python {toxinidir}/manage.py makemigrations --check --dry-run
     django30: python {toxinidir}/manage.py makemigrations --check --dry-run
     django31: python {toxinidir}/manage.py makemigrations --check --dry-run
+    djangomaster: python {toxinidir}/manage.py makemigrations --check --dry-run
     core: py.test --cov=guardian
     docs: sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
     example: python manage.py test
@@ -38,3 +40,4 @@ deps =
     django22: django>=2.2,<2.3
     django30: django>=3.0,<3.1
     django31: django>=3.1,<3.2
+    djangomaster: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
Travis tests against the django master branch. However, this is missing from the tox matrix. 