### PR TITLE
Run tests against Django 3.2 and adjust test setup a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,12 +68,12 @@ matrix:
     - { python: 3.8, env: [*djangomain, *mysql], <<: *mariadb}
     - { python: 3.8, env: [*djangomain, *sqlite]}
 
-    - { python: 3.9-dev, env: [*django31, *postgres], <<: *pgdb}
-    - { python: 3.9-dev, env: [*django31, *mysql], <<: *mariadb}
-    - { python: 3.9-dev, env: [*django31, *sqlite]}
-    - { python: 3.9-dev, env: [*djangomain, *postgres], <<: *pgdb}
-    - { python: 3.9-dev, env: [*djangomain, *mysql], <<: *mariadb}
-    - { python: 3.9-dev, env: [*djangomain, *sqlite]}
+    - { python: 3.9, env: [*django31, *postgres], <<: *pgdb}
+    - { python: 3.9, env: [*django31, *mysql], <<: *mariadb}
+    - { python: 3.9, env: [*django31, *sqlite]}
+    - { python: 3.9, env: [*djangomain, *postgres], <<: *pgdb}
+    - { python: 3.9, env: [*djangomain, *mysql], <<: *mariadb}
+    - { python: 3.9, env: [*djangomain, *sqlite]}
   allow_failures:
     - env: [*djangomain, *postgres]
     - env: [*djangomain, *mysql]

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ templates:
   django22: &django22 DJANGO_VERSION=2.2.*
   django30: &django30 DJANGO_VERSION=3.0.*
   django31: &django31 DJANGO_VERSION=3.1.*
-  djangomaster: &djangomaster DJANGO_VERSION=master
+  djangomain: &djangomain DJANGO_VERSION=main
 
   postgres: &postgres DATABASE_URL=postgres://postgres@/django_guardian
   mysql: &mysql DATABASE_URL=mysql://root:@localhost/django_guardian
@@ -64,17 +64,17 @@ matrix:
     - { python: 3.8, env: [*django31, *postgres], <<: *pgdb}
     - { python: 3.8, env: [*django31, *mysql], <<: *mariadb}
     - { python: 3.8, env: [*django31, *sqlite]}
-    - { python: 3.8, env: [*djangomaster, *postgres], <<: *pgdb}
-    - { python: 3.8, env: [*djangomaster, *mysql], <<: *mariadb}
-    - { python: 3.8, env: [*djangomaster, *sqlite]}
+    - { python: 3.8, env: [*djangomain, *postgres], <<: *pgdb}
+    - { python: 3.8, env: [*djangomain, *mysql], <<: *mariadb}
+    - { python: 3.8, env: [*djangomain, *sqlite]}
 
     - { python: 3.9-dev, env: [*django31, *postgres], <<: *pgdb}
     - { python: 3.9-dev, env: [*django31, *mysql], <<: *mariadb}
     - { python: 3.9-dev, env: [*django31, *sqlite]}
-    - { python: 3.9-dev, env: [*djangomaster, *postgres], <<: *pgdb}
-    - { python: 3.9-dev, env: [*djangomaster, *mysql], <<: *mariadb}
-    - { python: 3.9-dev, env: [*djangomaster, *sqlite]}
+    - { python: 3.9-dev, env: [*djangomain, *postgres], <<: *pgdb}
+    - { python: 3.9-dev, env: [*djangomain, *mysql], <<: *mariadb}
+    - { python: 3.9-dev, env: [*djangomain, *sqlite]}
   allow_failures:
-    - env: [*djangomaster, *postgres]
-    - env: [*djangomaster, *mysql]
-    - env: [*djangomaster, *sqlite]
+    - env: [*djangomain, *postgres]
+    - env: [*djangomain, *mysql]
+    - env: [*djangomain, *sqlite]

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Requirements
 * Python 3.5+
 * A supported version of Django (currently 2.2+)
 
-Travis CI tests on Django version 2.2, 3.0, 3.1, and master.
+Travis CI tests on Django version 2.2, 3.0, 3.1, and main.
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Requirements
 * Python 3.5+
 * A supported version of Django (currently 2.2+)
 
-Travis CI tests on Django version 2.2, 3.0, 3.1, and main.
+Travis CI tests on Django version 2.2, 3.0, 3.1, 3.2, and main.
 
 Installation
 ------------

--- a/contrib/travis/install.sh
+++ b/contrib/travis/install.sh
@@ -7,9 +7,9 @@ pip install -U pip
 # Array of packages
 PACKAGES=('mock==1.0.1' 'pytest' 'pytest-django' 'pytest-cov' 'django-environ' 'setuptools_scm' 'pyupgrade')
 
-# Install django master or version
-if [[ "$DJANGO_VERSION" == 'master' ]]; then
-    PACKAGES+=('https://github.com/django/django/archive/master.tar.gz');
+# Install django main or version
+if [[ "$DJANGO_VERSION" == 'main' ]]; then
+    PACKAGES+=('https://github.com/django/django/archive/main.tar.gz');
 else
     PACKAGES+=("Django==$DJANGO_VERSION");
 fi;

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
                  'Framework :: Django :: 2.2',
                  'Framework :: Django :: 3.0',
                  'Framework :: Django :: 3.1',
+                 'Framework :: Django :: 3.2',
                  'Intended Audience :: Developers',
                  'License :: OSI Approved :: BSD License',
                  'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = # sort by django version, next by python version
     {core,example,docs}-py{35,36,37,38}-django22,
     {core,example,docs}-py{36,37,38}-django30,
     {core,example,docs}-py{36,37,38,39}-django31,
-    {core,example,docs}-py{38,39}-djangomaster,
+    {core,example,docs}-py{38,39}-djangomain,
 
 [testenv]
 passenv = DATABASE_URL
@@ -21,7 +21,7 @@ commands =
     django22: python {toxinidir}/manage.py makemigrations --check --dry-run
     django30: python {toxinidir}/manage.py makemigrations --check --dry-run
     django31: python {toxinidir}/manage.py makemigrations --check --dry-run
-    djangomaster: python {toxinidir}/manage.py makemigrations --check --dry-run
+    djangomain: python {toxinidir}/manage.py makemigrations --check --dry-run
     core: py.test --cov=guardian
     docs: sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
     example: python manage.py test
@@ -40,4 +40,4 @@ deps =
     django22: django>=2.2,<2.3
     django30: django>=3.0,<3.1
     django31: django>=3.1,<3.2
-    djangomaster: https://github.com/django/django/archive/master.tar.gz
+    djangomain: https://github.com/django/django/archive/main.tar.gz

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = # sort by django version, next by python version
     {core,example,docs}-py{35,36,37,38}-django22,
     {core,example,docs}-py{36,37,38}-django30,
     {core,example,docs}-py{36,37,38,39}-django31,
+    {core,example,docs}-py{36,37,38,39}-django32,
     {core,example,docs}-py{38,39}-djangomain,
 
 [testenv]
@@ -21,6 +22,7 @@ commands =
     django22: python {toxinidir}/manage.py makemigrations --check --dry-run
     django30: python {toxinidir}/manage.py makemigrations --check --dry-run
     django31: python {toxinidir}/manage.py makemigrations --check --dry-run
+    django32: python {toxinidir}/manage.py makemigrations --check --dry-run
     djangomain: python {toxinidir}/manage.py makemigrations --check --dry-run
     core: py.test --cov=guardian
     docs: sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
@@ -40,4 +42,5 @@ deps =
     django22: django>=2.2,<2.3
     django30: django>=3.0,<3.1
     django31: django>=3.1,<3.2
+    django32: django>=3.2b1,<3.3
     djangomain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
- Run tests against Django 3.2 (the next LTS release; expected in April 2021)
- Run tests against Python 3.9 stable instead of dev (wasn't available back at the time)
- Django renamed the dev branch from `master` to `main` (see commit message for link to PR and mailing list discussion)