### PR TITLE
Mention GitHub Actions instead of Travis CI everywhere

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+* Switch from Travis CI to `GitHub Actions`_
+
 Release 2.3.0 (June 6, 2020)
 ===============================
 
@@ -435,6 +440,7 @@ Release 0.1.0 (Jun 6, 2010)
 .. _grappelli: https://github.com/sehmaschine/django-grappelli
 .. _tox: http://tox.testrun.org/
 .. _travis: http://travis-ci.org/
+.. _GitHub Actions: https://github.com/django-guardian/django-guardian/actions
 
 
 .. vim: ft=rst

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 django-guardian
 ===============
 
-.. image:: https://travis-ci.org/django-guardian/django-guardian.svg?branch=devel
-  :target: https://travis-ci.org/django-guardian/django-guardian
+.. image:: https://github.com/django-guardian/django-guardian/workflows/Tests/badge.svg?branch=devel
+  :target: https://github.com/django-guardian/django-guardian/actions/workflows/tests.yml
 
 .. image:: https://img.shields.io/pypi/v/django-guardian.svg
     :target: https://pypi.python.org/pypi/django-guardian
@@ -25,7 +25,7 @@ Requirements
 * Python 3.5+
 * A supported version of Django (currently 2.2+)
 
-Travis CI tests on Django version 2.2, 3.0, 3.1, 3.2, and main.
+GitHub Actions run tests against Django versions 2.2, 3.0, 3.1, 3.2, and main.
 
 Installation
 ------------

--- a/docs/develop/testing.rst
+++ b/docs/develop/testing.rst
@@ -100,21 +100,20 @@ First time should take some time (it needs to create separate virtual
 environments and pull dependencies) but would ensure everything is fine.
 
 
-Travis CI
----------
+GitHub Actions
+--------------
 
-.. versionadded:: 1.0.4
+.. versionadded:: 2.4.0
 
-.. image:: https://secure.travis-ci.org/django-guardian/django-guardian.png?branch=master
-  :target: http://travis-ci.org/django-guardian/django-guardian
+.. image:: https://github.com/django-guardian/django-guardian/workflows/Tests/badge.svg?branch=devel
+  :target: https://github.com/django-guardian/django-guardian/actions/workflows/tests.yml
 
-Recently we have added support for Travis_, continuous integration server so it
-is even more easy to follow if test fails with new commits: http://travis-ci.org/#!/lukaszb/django-guardian.
+Recently we have added support for `GitHub Actions`_ so it is even more easy to follow
+if test fails with new commits.
 
 
 .. _owasp: http://www.owasp.org/
 .. _issue-tracker: http://github.com/lukaszb/django-guardian
 .. _coverage: http://nedbatchelder.com/code/coverage/
 .. _tox: http://pypi.python.org/pypi/tox
-.. _travis: http://travis-ci.org/
-
+.. _GitHub Actions: https://github.com/django-guardian/django-guardian/actions

--- a/docs/develop/testing.rst
+++ b/docs/develop/testing.rst
@@ -108,7 +108,7 @@ GitHub Actions
 .. image:: https://github.com/django-guardian/django-guardian/workflows/Tests/badge.svg?branch=devel
   :target: https://github.com/django-guardian/django-guardian/actions/workflows/tests.yml
 
-Recently we have added support for `GitHub Actions`_ so it is even more easy to follow
+We have support for `GitHub Actions`_ to make it easy to follow
 if test fails with new commits.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,8 +9,8 @@
 
 **Documentation**:
 
-.. image:: https://secure.travis-ci.org/django-guardian/django-guardian.png?branch=master
-  :target: http://travis-ci.org/django-guardian/django-guardian
+.. image:: https://github.com/django-guardian/django-guardian/workflows/Tests/badge.svg?branch=devel
+  :target: https://github.com/django-guardian/django-guardian/actions/workflows/tests.yml
 
 .. toctree::
     :maxdepth: 2
@@ -30,4 +30,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-


### PR DESCRIPTION
Missed in django-guardian/django-guardian#736
Supersedes django-guardian/django-guardian#725