### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,11 @@ jobs:
         include:
           - python-version: "3.10"
             django: 3.2.0
-          - python-version: 3.8
+          - python-version: "3.8"
             django: main
-          - python-version: 3.9
+          - python-version: "3.9"
             django: main
-          - python-version: 3.10
+          - python-version: "3.10"
             django: main
 
     services:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         django: [2.2.17, 3.0.11, 3.1.3, 3.2.0]
         include:
           - python-version: 3.8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
         django: [2.2.17, 3.0.11, 3.1.3, 3.2.0]
         include:
+          - python-version: "3.10"
+            django: 3.2.0
           - python-version: 3.8
             django: main
           - python-version: 3.9
+            django: main
+          - python-version: 3.10
             django: main
 
     services:

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,8 @@ setup(
                  'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: 3.8',
                  'Programming Language :: Python :: 3.9',
+                 'Programming Language :: Python :: 3.9',
+                 'Programming Language :: Python :: 3.10',
                  ],
     test_suite='tests.main',
     cmdclass={'flakes': RunFlakesCommand},

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist = # sort by django version, next by python version
     {core,example,docs}-py{35,36,37,38}-django22,
     {core,example,docs}-py{36,37,38}-django30,
     {core,example,docs}-py{36,37,38,39}-django31,
-    {core,example,docs}-py{36,37,38,39}-django32,
-    {core,example,docs}-py{38,39}-djangomain,
+    {core,example,docs}-py{36,37,38,39,310}-django32,
+    {core,example,docs}-py{38,39,310}-djangomain,
 
 [testenv]
 passenv = DATABASE_URL
@@ -15,6 +15,7 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
 changedir =
     example: example_project
     docs: docs


### PR DESCRIPTION
Django 3.2 is currently the only Django release to support Python 3.10: https://docs.djangoproject.com/en/3.2/faq/install/#what-python-version-can-i-use-with-django

Django 3.2.9 is needed to fully support Python 3.10 (and fixes `distutils` `DeprecationWarning`). This PR should be ready around November 1 when 3.2.9 is released: https://docs.djangoproject.com/en/4.0/releases/3.2.9/