### PR TITLE
Place edit at the beginning of the table

### DIFF
--- a/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage.html
+++ b/guardian/templates/admin/guardian/contrib/grappelli/obj_perms_manage.html
@@ -53,6 +53,9 @@
                             {% for user, user_perms in users_perms.items %}
                             <tr class="grp-row {% cycle 'grp-row-even' 'grp-row-odd' %}">
                                 <td>{{ user }}</td>
+                                <td>
+                                    <a href="user-manage/{{ user.id|safe }}/">{% trans "Edit" %}</a>
+                                </td>
                                 {% for perm in model_perms %}
                                 <td>
                                     {% if perm.codename in user_perms %}
@@ -62,9 +65,6 @@
                                     {% endif %}
                                 </td>
                                 {% endfor %}
-                                <td>
-                                    <a href="user-manage/{{ user.id|safe }}/">{% trans "Edit" %}</a>
-                                </td>
                             </tr>
                             {% endfor %}
                         </tbody>
@@ -114,6 +114,9 @@
                             {% for group, group_perms in groups_perms.items %}
                             <tr class="grp-row {% cycle 'grp-row-even' 'grp-row-odd' %}">
                                 <td>{{ group }}</td>
+                                <td>
+                                    <a href="group-manage/{{ group.id|safe }}/">{% trans "Edit" %}</a>
+                                </td>
                                 {% for perm in model_perms %}
                                 <td>
                                     {% if perm.codename in group_perms %}
@@ -123,9 +126,6 @@
                                     {% endif %}
                                 </td>
                                 {% endfor %}
-                                <td>
-                                    <a href="group-manage/{{ group.id|safe }}/">{% trans "Edit" %}</a>
-                                </td>
                             </tr>
                             {% endfor %}
                         </tbody>


### PR DESCRIPTION
When the number of permissions is large and because of the description of these, the table that is rendered when having grappelli installed cannot fit in a screen.
When using grappelli there's also no way to override the templates, since that's returned by `get_obj_perms_manage_template()`.

The idea here is to have the edit button as close to the left as possible, so user doesn't have to zoom out to see it.
![image](https://user-images.githubusercontent.com/7312236/142405324-3e26a3e5-1b82-49ec-99f5-7bf97608d328.png)

