### PR TITLE
Use shortcuts.assign_perm in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,8 +76,8 @@ Lets start really quickly:
       >>> admins = Group.objects.create(name='admins')
       >>> jack.has_perm('change_group', admins)
       False
-      >>> from guardian.models import UserObjectPermission
-      >>> UserObjectPermission.objects.assign_perm('change_group', jack, obj=admins)
+      >>> from guardian.shortcuts import assign_perm
+      >>> assign_perm('change_group', jack, obj=admins)
       <UserObjectPermission: admins | jack | change_group>
       >>> jack.has_perm('change_group', admins)
       True


### PR DESCRIPTION
We have a nice helper `guardian.shortcuts.assign_perm`. It abstracts module-level permission (see #766) and direct foreign keys. I personally use it everywhere, so I suggest update example to encourage users to do the same. 