### PR TITLE
Derive auth backend from base django auth banckend

### DIFF
--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import BaseBackend
 from django.db import models
 from guardian.conf import settings
 from guardian.core import ObjectPermissionChecker
@@ -47,13 +48,10 @@ def check_support(user_obj, obj):
     return obj_support and user_support, user_obj
 
 
-class ObjectPermissionBackend:
+class ObjectPermissionBackend(BaseBackend):
     supports_object_permissions = True
     supports_anonymous_user = True
     supports_inactive_user = True
-
-    def authenticate(self, request, username=None, password=None):
-        return None
 
     def has_perm(self, user_obj, perm, obj=None):
         """


### PR DESCRIPTION
Default methods for authentication backends are already defined in [Basebackend](https://github.com/django/django/blob/11661d3815f273a6968cf09ecc678cf6fa6dcfcd/django/contrib/auth/backends.py#L8).

It is better to derive from this class than to add dummy methods to cover them.