### PR TITLE
Add Django 4.0 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:10.1
+        image: mariadb:10.2
         env:
           MYSQL_ROOT_PASSWORD: mariadb
         ports:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,12 @@ jobs:
           - python-version: "3.10"
             django: 3.2.0
           - python-version: "3.8"
+            django: 4.0.0
+          - python-version: "3.9"
+            django: 4.0.0
+          - python-version: "3.10"
+            django: 4.0.0
+          - python-version: "3.8"
             django: main
           - python-version: "3.9"
             django: main

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Requirements
 * Python 3.5+
 * A supported version of Django (currently 2.2+)
 
-GitHub Actions run tests against Django versions 2.2, 3.0, 3.1, 3.2, and main.
+GitHub Actions run tests against Django versions 2.2, 3.0, 3.1, 3.2, 4.0, and main.
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
                  'Framework :: Django :: 3.0',
                  'Framework :: Django :: 3.1',
                  'Framework :: Django :: 3.2',
+                 'Framework :: Django :: 4.0',
                  'Intended Audience :: Developers',
                  'License :: OSI Approved :: BSD License',
                  'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = # sort by django version, next by python version
     {core,example,docs}-py{36,37,38}-django30,
     {core,example,docs}-py{36,37,38,39}-django31,
     {core,example,docs}-py{36,37,38,39,310}-django32,
+    {core,example,docs}-py{38,39,310}-django40,
     {core,example,docs}-py{38,39,310}-djangomain,
 
 [testenv]
@@ -44,4 +45,5 @@ deps =
     django30: django~=3.0.11
     django31: django~=3.1.3
     django32: django~=3.2.0
+    django40: django~=4.0.0
     djangomain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
- Add Django 4.0 support
- Bump MariaDB test image to 10.2 to support Django `main` testing.

When merging, please squash the commits with the GitHub UI.