### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/develop/overview.rst
+++ b/docs/develop/overview.rst
@@ -70,7 +70,7 @@ Here is a quick how to:
 Why my issue/pull request was closed?
 -------------------------------------
 
-We usually put an explonation while we close issue or PR. It might be for
+We usually put an explanation while we close issue or PR. It might be for
 various reasons, i.e. there were no reply for over a month after our last
 comment, there were no tests for the changes etc.
 
@@ -82,7 +82,7 @@ To enroll a new release you should perform the following task:
 
 * Ensure file ``CHANGES`` reflects all important changes.
 * Ensure file ``CHANGES`` includes a new version identifier and current release date.
-* Execute ``bumpversion patch`` (or accordinly - see `Semantic Versioning 2.0 <http://semver.org/>`_ ) to reflects changes in codebase.
+* Execute ``bumpversion patch`` (or accordingly - see `Semantic Versioning 2.0 <http://semver.org/>`_ ) to reflects changes in codebase.
 * Commit changes of codebase, e.g. ``git commit -m "Release 1.4.8" -a``.
 * Tag a new release, e.g. ``git tag "v1.4.8"``.
 * Push new tag to repo - ``git push origin --tags``.

--- a/docs/develop/testing.rst
+++ b/docs/develop/testing.rst
@@ -7,7 +7,7 @@ Introduction
 ------------
 
 ``django-guardian`` is extending capabilities of Django's authorization
-facilities and as so, it changes it's security somehow. It is extremaly
+facilities and as so, it changes it's security somehow. It is extremely
 important to provide as simplest :ref:`api` as possible.
 
 According to OWASP_, `broken authentication
@@ -26,7 +26,7 @@ library), please **DO NOT** create a public issue but contact me directly
 Running tests
 -------------
 
-Tests are run by Django's buildin test runner. To call it simply run::
+Tests are run by Django's building test runner. To call it simply run::
 
     $ python setup.py test
 
@@ -45,7 +45,7 @@ Coverage_ is a tool for measuring code coverage of Python programs. It is great
 for tests and we use it as a backup - we try to cover 100% of the code used by
 ``django-guardian``. This of course does *NOT* mean that if all of the codebase
 is covered by tests we can be sure there is no bug (as specification of almost
-all applications requries some unique scenarios to be tested). On the other hand
+all applications requires some unique scenarios to be tested). On the other hand
 it definitely helps to track missing parts.
 
 To run tests with coverage_ support and show the report after we have provided

--- a/docs/userguide/performance.rst
+++ b/docs/userguide/performance.rst
@@ -103,7 +103,7 @@ From now on, ``guardian`` will figure out that ``Project`` model has direct
 relation for user/group object permissions and will use those models. It is
 also possible to use only user or only group-based direct relation, however it
 is discouraged (it's not consistent and might be a quick road to hell from the
-maintainence point of view, especially).
+maintenance point of view, especially).
 
 To temporarily disable the detection of this direct relation model, add
 ``enabled = False`` to the object permission model classes. This is useful to

--- a/guardian/testapp/tests/test_decorators.py
+++ b/guardian/testapp/tests/test_decorators.py
@@ -240,7 +240,7 @@ class PermissionRequiredTest(TestDataMixin, TestCase):
 
     def test_user_has_access_on_model_with_metaclass(self):
         """
-        Test to the fix issues of comparaison made via type()
+        Test to the fix issues of comparison made via type()
         in the decorator. In the case of a `Model` implementing
         a custom metaclass, the decorator fail because type
         doesn't return `ModelBase`

--- a/guardian/testapp/tests/test_orphans.py
+++ b/guardian/testapp/tests/test_orphans.py
@@ -21,7 +21,7 @@ user_module_name = User._meta.model_name
 class OrphanedObjectPermissionsTest(TestCase):
 
     def setUp(self):
-        # Create objects for which we would assing obj perms
+        # Create objects for which we would assign obj perms
         self.target_user1 = User.objects.create(username='user1')
         self.target_group1 = Group.objects.create(name='group1')
         self.target_obj1 = ContentType.objects.create(


### PR DESCRIPTION
There are small typos in:
- docs/develop/overview.rst
- docs/develop/testing.rst
- docs/userguide/performance.rst
- guardian/testapp/tests/test_decorators.py
- guardian/testapp/tests/test_orphans.py

Fixes:
- Should read `requires` rather than `requries`.
- Should read `maintenance` rather than `maintainence`.
- Should read `extremely` rather than `extremaly`.
- Should read `explanation` rather than `explonation`.
- Should read `comparison` rather than `comparaison`.
- Should read `building` rather than `buildin`.
- Should read `assign` rather than `assing`.
- Should read `accordingly` rather than `accordinly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md