### PR TITLE
Add async support to PermissionRequiredMixin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,3 +62,4 @@ Authors ordered by first contribution
 - Davis Raymond Muro <davisraymondmuro@gmail.com>
 - Richard de Wit <henk.exe@gmail.com>
 - Pedro Rojas Gavidia <pedrorojas.gavidia@gmail.com> @pedrorojasg
+- Giannis Terzopoulos <terzo.giannis@gmail.com>


### PR DESCRIPTION
Adds asynchronous support to `PermissionRequiredMixin`.

When a view's HTTP handlers are coroutines, Django classifies it as
asynchronous and the mixin runs its permission check on the asynchronous path.
Synchronous views are untouched apart from a single flag check in `dispatch()`,
so existing code keeps its current behaviour.

Following the review on this PR and Django's own naming convention, the
asynchronous methods are `a`-prefixed sister methods rather than replacements:

| Synchronous               | Asynchronous               |
|---------------------------|----------------------------|
| `get_permission_object()` | `aget_permission_object()` |
| `check_permissions()`     | `acheck_permissions()`     |
| `dispatch()`              | `adispatch()`              |

`aget_permission_object()` runs the synchronous `get_permission_object()` in a
thread by default, so `permission_object`, `get_object()` and `object` keep
working. Override it to use the asynchronous ORM API. An `async def
get_object()` or `async def get_permission_object()` on the view is awaited as
well.

`get_required_permissions()`, `get_object_permission_denied_message()` and
`on_permission_check_fail()` have no asynchronous counterpart; they are all
called from a single worker thread, so overrides may run queries.

### Supported versions

The asynchronous path requires **Django 4.2**. Django 4.1.2 is the first
release where the response for a disallowed HTTP method is awaitable, but 4.1
is end of life and is not covered by this project's test matrix, so 4.2 is the
floor. It also keeps the version check to two components, since comparing
`django.VERSION` with three is deprecated in Django's development version.

On older versions the mixin uses its synchronous path exactly as before.

### Limitations

- `LoginRequiredMixin` and `PermissionListMixin` have no asynchronous support
  yet. Django's own `LoginRequiredMixin` has the same gap, and the guardian
  side is tracked separately.
- Django's generic views provide synchronous handlers by default; they only
  take the asynchronous path when every effective handler is overridden with a
  coroutine.

### Testing

The asynchronous path is covered by tests for dispatch through `as_view()`, a
full request through the test client with the real authentication middleware,
disallowed methods, `OPTIONS`, awaited `get_object()` overrides, and
synchronous hooks that query the database.

Verified locally on Django 4.1.1 (feature correctly skipped), 4.2, 5.0, 5.2,
6.0 and `main`, with Python 3.10 through 3.14, plus `mypy`, `ruff` and
`mkdocs build`.

Documentation: new "Asynchronous views" page in the user guide.
