### PR TITLE
ignore_conflicts on bulk create

### DIFF
--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -77,7 +77,7 @@ class BaseObjectPermissionManager(models.Manager):
                 else:
                     kwargs['content_object'] = instance
                 assigned_perms.append(self.model(**kwargs))
-        self.model.objects.bulk_create(assigned_perms)
+        self.model.objects.bulk_create(assigned_perms, ignore_conflicts=True)
 
         return assigned_perms
 
@@ -107,7 +107,7 @@ class BaseObjectPermissionManager(models.Manager):
                 self.model(**kwargs)
             )
 
-        return self.model.objects.bulk_create(to_add)
+        return self.model.objects.bulk_create(to_add, ignore_conflicts=True)
 
     def assign(self, perm, user_or_group, obj):
         """ Depreciated function name left in for compatibility"""


### PR DESCRIPTION
ignore_conflicts when bulk creating to assign permissions. In most (all) cases, I have found these conflicts would not need special attention so I think it will be ok to simply ignore them