### PR TITLE
Fix failing checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         ports:
           - 3306:3306
       postgres:
-        image: postgres:10-alpine
+        image: postgres:14-alpine
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,6 @@ jobs:
             django: 4.0.0
           - python-version: "3.10"
             django: 4.0.0
-          - python-version: "3.8"
-            django: main
-          - python-version: "3.9"
-            django: main
           - python-version: "3.10"
             django: main
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:10.2
+        image: mariadb:10.5
         env:
           MYSQL_ROOT_PASSWORD: mariadb
         ports:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
       postgres:
         image: postgres:14-alpine
         env:
+          PGUSER: postgres
           POSTGRES_PASSWORD: postgres
         options: >-
           --health-cmd pg_isready

--- a/AUTHORS
+++ b/AUTHORS
@@ -62,4 +62,3 @@ Authors ordered by first contribution
 - Davis Raymond Muro <davisraymondmuro@gmail.com>
 - Richard de Wit <henk.exe@gmail.com>
 - Pedro Rojas Gavidia <pedrorojas.gavidia@gmail.com> @pedrorojasg
-- Columbia University, SIS Development and Application Services

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -75,8 +75,7 @@ AUTHENTICATION_BACKENDS = (
 GUARDIAN_GET_INIT_ANONYMOUS_USER = 'core.models.get_custom_anon_user'
 
 PASSWORD_HASHERS = (
-    'django.contrib.auth.hashers.MD5PasswordHasher',
-    'django.contrib.auth.hashers.SHA1PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
 )
 
 AUTH_USER_MODEL = 'core.CustomUser'

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -295,15 +295,12 @@ def get_users_with_perms(obj, attach_perms=False, with_superusers=False,
             }
         else:
             user_filters = {'%s__content_object' % related_name: obj}
-        qset_filters = Q(**user_filters)
+        qset = Q(**user_filters)
         if only_with_perms_in is not None:
             permission_ids = Permission.objects.filter(content_type=ctype, codename__in=only_with_perms_in).values_list('id', flat=True)
-            qset_filters &= Q(**{
+            qset &= Q(**{
                 '%s__permission_id__in' % related_name: permission_ids,
                 })
-        if with_superusers:
-            qset_filters = qset_filters | Q(is_superuser=True)
-        qset = get_user_model().objects.filter(qset_filters).distinct()
         if with_group_users:
             group_model = get_group_obj_perms_model(obj)
             if group_model.objects.is_generic():
@@ -319,9 +316,11 @@ def get_users_with_perms(obj, attach_perms=False, with_superusers=False,
                 group_obj_perm_filters.update({
                     'permission_id__in': permission_ids,
                     })
-            group_ids = group_model.objects.filter(**group_obj_perm_filters).values_list('group_id', flat=True).distinct()
-            qset = qset.union(get_user_model().objects.filter(groups__in=group_ids).distinct())
-        return qset
+            group_ids = set(group_model.objects.filter(**group_obj_perm_filters).values_list('group_id', flat=True).distinct())
+            qset = qset | Q(groups__in=group_ids)
+        if with_superusers:
+            qset = qset | Q(is_superuser=True)
+        return get_user_model().objects.filter(qset).distinct()
     else:
         # TODO: Do not hit db for each user!
         users = {}

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -846,5 +846,5 @@ def filter_perms_queryset_by_objects(perms_queryset, objects):
         if perms_queryset.model.objects.is_generic():
             field = 'object_pk'
         return perms_queryset.filter(
-            **{'{}__in'.format(field): objects.values_list(
-                'pk', flat=True).distinct().order_by()})
+            **{'{}__in'.format(field): list(objects.values_list(
+                'pk', flat=True).distinct().order_by())})

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = # sort by django version, next by python version
     {core,example,docs}-py{36,37,38,39}-django31,
     {core,example,docs}-py{36,37,38,39,310}-django32,
     {core,example,docs}-py{38,39,310}-django40,
-    {core,example,docs}-py{38,39,310}-djangomain,
+    {core,example,docs}-py{310}-djangomain,
 
 [testenv]
 passenv = DATABASE_URL


### PR DESCRIPTION
In order to get guardian back on track and keep it active, we consider it essential that the github actions run properly.

Currently, all tests on the devel branch are failing, as described in https://github.com/django-guardian/django-guardian/issues/818.

With this PR we revert the changes of the last 2 merged PRs, because before these all tests pass, #812 and #768. We should also set up a policy that tests cannot be merged if they fail.

In addition, we introduce minimal changes in this PR that make all checks green again.

We also suggest to investigate #812 and #768 again to see why the problem with the checks occurred. We should re-open the issues.