### PR TITLE
Correct dispatch Flow in PermissionRequiredMixin for API View with Anonymous Users

### DIFF
--- a/guardian/mixins.py
+++ b/guardian/mixins.py
@@ -204,13 +204,17 @@ class PermissionRequiredMixin:
         """
 
     def dispatch(self, request, *args, **kwargs):
+        dispatch_response = super().dispatch(request, *args, **kwargs)
+        
         self.request = request
         self.args = args
         self.kwargs = kwargs
+
         response = self.check_permissions(request)
         if response:
             return response
-        return super().dispatch(request, *args, **kwargs)
+
+        return dispatch_response
 
 
 class GuardianUserMixin:


### PR DESCRIPTION
**Issue:**
When using `PermissionRequiredMixin` with an API view in Django, `request.user` is sometimes recognized as `anonymous` before the `dispatch` method is called. This leads to incorrect permission checks, as the user is not properly initialized.

**Solution:**
The fix ensures that `super().dispatch(request, *args, **kwargs)` is called first to initialize the request and set `request.user` correctly. This allows the permission checks to work as expected, even when the user is anonymous.

**Changes:**
- The `dispatch` method now calls `super().dispatch(request, *args, **kwargs)` before performing permission checks. This ensures that the request is properly processed and the `request.user` is correctly set.
- After the parent dispatch, the `check_permissions` method is called to validate if the user has the required permissions.
- If the permissions check fails, the appropriate response is returned.

This fix improves compatibility with API views and ensures accurate permission handling in all cases.