### PR TITLE
Re apply #812 using correct lookup method

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -835,12 +835,18 @@ def _handle_pk_field(queryset):
     return None
 
 def filter_perms_queryset_by_objects(perms_queryset, objects):
-    if not isinstance(objects, QuerySet):
-        return perms_queryset
-    else:
+    if isinstance(objects, QuerySet):
         field = 'content_object__pk'
         if perms_queryset.model.objects.is_generic():
             field = 'object_pk'
+
+        handle_pk_field = _handle_pk_field(objects)
+        if handle_pk_field is not None:
+            objects = objects.values(_pk=handle_pk_field('pk'))
+        else:
+            objects = objects.values('pk')
         return perms_queryset.filter(
-            **{'{}__in'.format(field): list(objects.values_list(
-                'pk', flat=True).distinct().order_by())})
+            **{'{}__in'.format(field): objects}
+        )
+    else:
+        return perms_queryset


### PR DESCRIPTION
In #812 it was introduced a too optimistic way to filter on the database based on generic-foreign-key relationship, since the type of the value can change this may results in some exceptions.

This change does not require any further test it should and must work with existing tests.

The logic in `filter_perms_queryset_by_objects` was also changed into "positive-check", for readability.