### PR TITLE
Fix readthedocs search text contrast

### DIFF
--- a/docs/css/readthedocs.css
+++ b/docs/css/readthedocs.css
@@ -1,0 +1,4 @@
+:root {
+    /* Ensure that search text color is not low contrast */
+    --readthedocs-search-color: black;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,8 @@ theme:
   custom_dir: docs/overrides
 extra_javascript:
   - javascript/readthedocs.js
+extra_css:
+  - css/readthedocs.css
 nav:
   - Home: index.md
   - Installation: installation.md


### PR DESCRIPTION
# Description 

Small fix to make the sure search text is always readable in dark mode. 

- [readthedocs addon css variable reference](https://docs.readthedocs.com/platform/stable/addons.html\#css-variables-reference)
- [Adding extra css to mkdocs](https://www.mkdocs.org/user-guide/configuration/#extra_css)

This should fix this cosmetic/accessibility issue with the latest version of the docs. 

<img width="775" alt="image" src="https://github.com/user-attachments/assets/5132879f-549e-43f0-8594-74895a3a7369" />
