### PR TITLE
Remove EOL python 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         django: ["3.2.25", "4.1.13", "4.2.16", "5.0.9", "5.1.5", "main"]
         exclude:
           - python-version: "3.13"
@@ -40,12 +40,6 @@ jobs:
           - python-version: "3.9"
             django: "5.0.9"
           - python-version: "3.9"
-            django: "main"
-          - python-version: "3.8"
-            django: "5.1.5"
-          - python-version: "3.8"
-            django: "5.0.9"
-          - python-version: "3.8"
             django: "main"
 
     services:

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Online documentation is available at https://django-guardian.readthedocs.io/.
 Requirements
 ------------
 
-* Python 3.8+
+* Python 3.9+
 * A supported version of Django (currently 3.2+)
 
 GitHub Actions run tests against Django versions 3.2, 4.1, 4.2, 5.0, 5.1, and main.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(readme_file) as f:
 setup(
     name='django-guardian',
     version=version,
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     url='https://github.com/django-guardian/django-guardian',
     author='Lukasz Balcerzak',
     author_email='lukaszbalcerzak@gmail.com',
@@ -44,7 +44,6 @@ setup(
                  'Topic :: Security',
                  'Programming Language :: Python :: 3',
                  'Programming Language :: Python :: 3 :: Only',
-                 'Programming Language :: Python :: 3.8',
                  'Programming Language :: Python :: 3.9',
                  'Programming Language :: Python :: 3.10',
                  'Programming Language :: Python :: 3.11',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = # sort by django version, next by python version
-    {core,example,docs}-py{38,39,310}-django32,
-    {core,example,docs}-py{38,39,310,311}-django41,
-    {core,example,docs}-py{38,39,310,311}-django42,
+    {core,example,docs}-py{39,310}-django32,
+    {core,example,docs}-py{39,310,311}-django41,
+    {core,example,docs}-py{39,310,311}-django42,
     {core,example,docs}-py{310,311,312}-django50,
     {core,example,docs}-py{310,311,312,313}-django51,
     {core,example,docs}-py{310,311,312,313}-djangomain,
@@ -10,7 +10,6 @@ envlist = # sort by django version, next by python version
 [testenv]
 passenv = DATABASE_URL
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11


### PR DESCRIPTION
I'm currently overhauling the build process, tooling and dev tools and the support for python 3.8 is causing a bit of an issue with dev dependencies.

Rather than going back through, pinning versions to earlier ones that supported python 3.8, adding lots of exceptions in the build matrix etc, I'm deprecating support for python 3.8, which is past its EOL date. *This doesn't mean django-guardian won't run on 3.8, it just means that you won't be able to develop it on 3.8, and that it won't be tested on 3.8*. 