### PR TITLE
Change bulk removal to be consistent with bulk assignment

### DIFF
--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -150,19 +150,53 @@ class BaseObjectPermissionManager(models.Manager):
         """
         filters = Q(**{self.user_or_group_field: user_or_group})
 
-        if isinstance(perm, Permission):
-            filters &= Q(permission=perm)
+        if isinstance(queryset, list):
+            ctype = get_content_type(queryset[0])
         else:
             ctype = get_content_type(queryset.model)
-            filters &= Q(permission__codename=perm,
-                         permission__content_type=ctype)
+
+        if isinstance(perm, Permission):
+            permission = perm
+        else:
+            permission = Permission.objects.get(content_type=ctype, codename=perm)
+
+        filters &= Q(permission=permission)
 
         if self.is_generic():
-            filters &= Q(object_pk__in=[str(pk) for pk in queryset.values_list('pk', flat=True)])
+            if isinstance(queryset, list):
+                filters &= Q(object_pk__in=[str(obj.pk) for obj in queryset])
+            else:
+                filters &= Q(object_pk__in=[str(pk) for pk in queryset.values_list('pk', flat=True)])
         else:
             filters &= Q(content_object__in=queryset)
 
         return self.filter(filters).delete()
+
+    def remove_perm_from_many(self, perm, users_or_groups, obj):
+        """
+        Bulk removes given `perm` for the object `obj` from a set of users or a set of groups.
+        """
+        ctype = get_content_type(obj)
+        if isinstance(perm, Permission):
+            permission = perm
+        else:
+            permission = Permission.objects.get(content_type=ctype, codename=perm)
+
+        filters = Q(permission=permission)
+
+        if self.is_generic():
+            filters &= Q(object_pk=obj.pk)
+        else:
+            filters &= Q(content_object=obj)
+
+        if isinstance(users_or_groups, list):
+            to_remove = [user.pk for user in users_or_groups]
+        else:
+            to_remove = users_or_groups.values_list('pk', flat=True)
+
+        filters &= Q(**{f'{self.user_or_group_field}_id__in': to_remove})
+
+        return self.model.objects.filter(filters).delete()
 
 
 class UserObjectPermissionManager(BaseObjectPermissionManager):

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -180,13 +180,25 @@ def remove_perm(perm, user_or_group=None, obj=None):
     if not isinstance(perm, Permission):
         perm = perm.split('.')[-1]
 
-    if isinstance(obj, QuerySet):
+    if isinstance(obj, (QuerySet, list)):
+        if isinstance(user_or_group, (QuerySet, list)):
+            raise MultipleIdentityAndObjectError("Only bulk operations on either users/groups OR objects supported")
         if user:
-            model = get_user_obj_perms_model(obj.model)
+            model = get_user_obj_perms_model(
+                    obj[0] if isinstance(obj, list) else obj.model)
             return model.objects.bulk_remove_perm(perm, user, obj)
         if group:
-            model = get_group_obj_perms_model(obj.model)
+            model = get_group_obj_perms_model(
+                    obj[0] if isinstance(obj, list) else obj.model)
             return model.objects.bulk_remove_perm(perm, group, obj)
+
+    if isinstance(user_or_group, (QuerySet, list)):
+        if user:
+            model = get_user_obj_perms_model(obj)
+            return model.objects.remove_perm_from_many(perm, user, obj)
+        if group:
+            model = get_group_obj_perms_model(obj)
+            return model.objects.remove_perm_from_many(perm, group, obj)
 
     if user:
         model = get_user_obj_perms_model(obj)

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -171,7 +171,7 @@ class AssignPermTest(ObjectPermissionTestCase):
             self.assertTrue(check.has_perm("delete_contenttype", obj))
 
 
-class MultipleIdentitiesOperationsTest(ObjectPermissionTestCase):
+class MultipleIdentitiesAssignTest(ObjectPermissionTestCase):
     """
     Tests assignment of permission to multiple users or groups
     """
@@ -277,6 +277,41 @@ class RemovePermTest(ObjectPermissionTestCase):
         for obj in self.ctype_qset:
             self.assertFalse(check.has_perm("change_contenttype", obj))
 
+    def test_user_remove_perm_list(self):
+        """
+        Test that one is able to remove permissions for a list of objects
+        from a user
+        """
+        # Assign perms first
+        assign_perm("add_contenttype", self.user, self.ctype_list)
+        assign_perm("change_contenttype", self.group, self.ctype_list)
+        assign_perm(self.get_permission("delete_contenttype"), self.user, self.ctype_list)
+        remove_perm("add_contenttype", self.user, self.ctype_list)
+        remove_perm("change_contenttype", self.group, self.ctype_list)
+        remove_perm(self.get_permission("delete_contenttype"), self.user, self.ctype_list)
+        for obj in self.ctype_list:
+            self.assertFalse(self.user.has_perm("add_contenttype", obj))
+            self.assertFalse(self.user.has_perm("change_contenttype", obj))
+            self.assertFalse(self.user.has_perm("delete_contenttype", obj))
+
+    def test_group_remove_perm_list(self):
+        """
+        Test that one is able to remove permissions for a list of
+        objects from a group
+        """
+        # Assign perms first
+        assign_perm("add_contenttype", self.group, self.ctype_list)
+        assign_perm("change_contenttype", self.group, self.ctype_list)
+        assign_perm(self.get_permission("delete_contenttype"), self.group, self.ctype_list)
+        remove_perm("add_contenttype", self.group, self.ctype_list)
+        remove_perm("change_contenttype", self.group, self.ctype_list)
+        remove_perm(self.get_permission("delete_contenttype"), self.group, self.ctype_list)
+        check = ObjectPermissionChecker(self.group)
+        for obj in self.ctype_list:
+            self.assertFalse(check.has_perm("add_contenttype", obj))
+            self.assertFalse(check.has_perm("change_contenttype", obj))
+            self.assertFalse(check.has_perm("delete_contenttype", obj))
+
     def test_user_remove_perm_global(self):
         # assign perm first
         perm = "contenttypes.change_contenttype"
@@ -297,6 +332,72 @@ class RemovePermTest(ObjectPermissionTestCase):
         perm_obj = Permission.objects.get(codename=codename,
                                           content_type__app_label=app_label)
         self.assertFalse(perm_obj in self.group.permissions.all())
+
+
+class MultipleIdentitiesRemoveTest(ObjectPermissionTestCase):
+    """
+    Tests removal of permission from multiple users or groups
+    """
+    def setUp(self):
+        super().setUp()
+        self.users_list = jim, bob = [
+            User.objects.create_user(username='jim'),
+            User.objects.create_user(username='bob')
+        ]
+        self.groups_list = jim_group, bob_group = [
+            Group.objects.create(name='jimgroup'),
+            Group.objects.create(name='bobgroup')
+        ]
+        jim_group.user_set.add(jim)
+        bob_group.user_set.add(bob)
+        self.users_qs = User.objects.exclude(username='AnonymousUser')
+        self.groups_qs = Group.objects.all()
+
+    def test_remove_from_many_users_queryset(self):
+        # Assign perms first
+        assign_perm("add_contenttype", self.users_qs, self.ctype)
+        assign_perm(self.get_permission("delete_contenttype"), self.users_qs, self.ctype)
+        remove_perm("add_contenttype", self.users_qs, self.ctype)
+        remove_perm(self.get_permission("delete_contenttype"), self.users_qs, self.ctype)
+        for user in self.users_list:
+            self.assertFalse(user.has_perm("add_contenttype", self.ctype))
+            self.assertFalse(user.has_perm("delete_contenttype", self.ctype))
+
+    def test_remove_from_many_users_list(self):
+        # Assign perms first
+        assign_perm("add_contenttype", self.users_list, self.ctype)
+        assign_perm(self.get_permission("delete_contenttype"), self.users_list, self.ctype)
+        remove_perm("add_contenttype", self.users_list, self.ctype)
+        remove_perm(self.get_permission("delete_contenttype"), self.users_list, self.ctype)
+        for user in self.users_list:
+            self.assertFalse(user.has_perm("add_contenttype", self.ctype))
+            self.assertFalse(user.has_perm("delete_contenttype", self.ctype))
+
+    def test_remove_from_many_groups_queryset(self):
+        # Assign perms first
+        assign_perm("add_contenttype", self.groups_qs, self.ctype)
+        assign_perm(self.get_permission("delete_contenttype"), self.groups_qs, self.ctype)
+        remove_perm("add_contenttype", self.groups_qs, self.ctype)
+        remove_perm(self.get_permission("delete_contenttype"), self.groups_qs, self.ctype)
+        for user in self.users_list:
+            self.assertFalse(user.has_perm("add_contenttype", self.ctype))
+            self.assertFalse(user.has_perm("delete_contenttype", self.ctype))
+
+    def test_remove_from_many_groups_list(self):
+        # Assign perms first
+        assign_perm("add_contenttype", self.groups_list, self.ctype)
+        assign_perm(self.get_permission("delete_contenttype"), self.groups_list, self.ctype)
+        remove_perm("add_contenttype", self.groups_list, self.ctype)
+        remove_perm(self.get_permission("delete_contenttype"), self.groups_list, self.ctype)
+        for user in self.users_list:
+            self.assertFalse(user.has_perm("add_contenttype", self.ctype))
+            self.assertFalse(user.has_perm("delete_contenttype", self.ctype))
+
+    def test_remove_from_multiple_identity_and_obj(self):
+        with self.assertRaises(MultipleIdentityAndObjectError):
+            remove_perm("add_contenttype", self.users_list, self.ctype_qset)
+        with self.assertRaises(MultipleIdentityAndObjectError):
+            remove_perm("add_contenttype", self.users_qs, self.ctype_qset)
 
 
 class GetPermsTest(ObjectPermissionTestCase):


### PR DESCRIPTION
## What?

This PR changes bulk removal to be consistent with bulk assignment by adding support for `list` in addition to `QuerySet` in `bulk_remove_perm` and adding support for bulk removal from many users or groups similar to bulk assignment to many users or groups.

## Why?

This was requested in https://github.com/django-guardian/django-guardian/issues/654 and although it has not seen much activity or further requests since, I personally still have this use case when updating permissions in bulk, both assignment and removal.

I prefer to write consistent code and `django-guardian` being inconsistent in this regard forces me to write assignment and removal differently, with the other accepting a queryset and the other using a for loop.