### PR TITLE
add support for non-User models in `get_identity` util

### DIFF
--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -83,6 +83,7 @@ def get_identity(identity):
         identity = get_anonymous_user()
 
     Group = get_group_obj_perms_model().group.field.related_model
+    UserModel = get_user_obj_perms_model().user.field.related_model
 
     # get identity from queryset model type
     if isinstance(identity, QuerySet):
@@ -93,12 +94,12 @@ def get_identity(identity):
             return None, identity
 
     # get identity from first element in list
-    if isinstance(identity, list) and isinstance(identity[0], get_user_model()):
+    if isinstance(identity, list) and isinstance(identity[0], UserModel):
         return identity, None
     if isinstance(identity, list) and isinstance(identity[0], Group):
         return None, identity
 
-    if isinstance(identity, get_user_model()):
+    if isinstance(identity, UserModel):
         return identity, None
     if isinstance(identity, Group):
         return None, identity


### PR DESCRIPTION
This PR encourages the decoupling of the authorization from the authentication models used in Django.
In most applications the two are mixed together and are served by the same model, however in complex multi-tenant applications the authentication is strictly separated by the authorization. 

The aim of this PR is to enable `django-guardian` to work with separate permission models. 

## Inspiration: in multi-tenant applications we require a strict separation between authentication and authorization

## Changes - explained

with `get_user_obj_perms_model` we are allowed to set the permission model that will be used for persisting permissions in the database. this allows us to point the user FK to a non-User model, however, the `get_identity` still relies on the User model explicitly.

the only requirement for the permission model is to extend the `PermissionsMixin` from django, rather to be the `get_user_model`.