### PR TITLE
Use generic types for get_objects_for_user

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -4,7 +4,7 @@ import warnings
 from collections import defaultdict
 from functools import partial, lru_cache
 from itertools import groupby
-from typing import Union, Any, Optional
+from typing import Union, Any, Optional, TypeVar, Type
 
 from django.apps import apps
 from django.contrib.auth import get_user_model
@@ -427,16 +427,17 @@ def get_groups_with_perms(obj: Model, attach_perms: bool = False) -> Union[Group
             group_perms_mapping[group_perm.group].append(group_perm.permission.codename)
         return dict(group_perms_mapping)
 
+T = TypeVar("T", bound=Model)
 
 def get_objects_for_user(
     user: Any,
     perms: Union[str, list[str]],
-    klass: Union[Model, Manager, QuerySet, None] = None,
+    klass: Union[T, Manager[T],QuerySet[T], None] = None,
     use_groups: bool = True,
     any_perm: bool = False,
     with_superuser: bool = True,
     accept_global_perms: bool = True,
-) -> list[Model]:
+) -> QuerySet[T]:
     """Get objects that a user has *all* the supplied permissions for.
 
     Parameters:

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -432,7 +432,7 @@ T = TypeVar("T", bound=Model)
 def get_objects_for_user(
     user: Any,
     perms: Union[str, list[str]],
-    klass: Union[T, Manager[T],QuerySet[T], None] = None,
+    klass: Union[Type[T], Manager[T],QuerySet[T], None] = None,
     use_groups: bool = True,
     any_perm: bool = False,
     with_superuser: bool = True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ maintainers = [
   { name = "Brian May", email = "brian@microcomaustralia.com.au" },
   { name = "Lukasz Balcerzak", email = "lukaszbalcerzak@gmail.com" },
   { name = "Adam Dobrawy", email = "guardian@jawnosc.tk" },
+  { name = "David Graham", email = "dpgraham4401@gmail.com" },
   { name = "Michael K." },
   { name = "Chris Maggiuli" },
   { name = "Bona Fide IT GmbH"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,6 @@ dev = [
     "pytest>=8.3.4",
     "pytest-cov>=5.0.0",
     "pytest-django>=4.9.0",
-    "tox>=4.26.0",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ dev = [
     "pytest>=8.3.4",
     "pytest-cov>=5.0.0",
     "pytest-django>=4.9.0",
+    "tox>=4.26.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Changes

1. Adds a fix for `guradian.shortcuts.get_objects_for_user` type annotations, [see discussion in issue 846](https://github.com/django-guardian/django-guardian/issues/864).
2. Adds myself to the list of maintainers. 

closes #864 

Note: I initially also added tox to the `dev` dependency group but reverted that change. 