### PR TITLE
Fix GitHub Actions badge image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # django-guardian
 
-[![Tests](https://github.com/django-guardian/django-guardian/workflows/Tests/badge.svg?branch=next)](https://github.com/django-guardian/django-guardian/actions/workflows/tests.yml)
+[![Tests](https://github.com/django-guardian/django-guardian/actions/workflows/tests.yml/badge.svg)](https://github.com/django-guardian/django-guardian/actions/workflows/tests.yml)
 [![PyPI version](https://img.shields.io/pypi/v/django-guardian.svg)](https://pypi.python.org/pypi/django-guardian)
 [![Python versions](https://img.shields.io/pypi/pyversions/django-guardian.svg)](https://pypi.python.org/pypi/django-guardian)
 


### PR DESCRIPTION
The `next` branch has been deleted so the badge URL is wrong.

This follows the latest docs from GitHub for creating a badge

- https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge