### PR TITLE
Reset content-type cache on post-migrate (refs #865)

### DIFF
--- a/guardian/apps.py
+++ b/guardian/apps.py
@@ -1,5 +1,6 @@
 from django.apps import AppConfig
 from django.conf import settings
+from django.db.models.signals import post_migrate
 
 from . import monkey_patch_group, monkey_patch_user
 
@@ -9,6 +10,9 @@ class GuardianConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
+        from .shortcuts import clear_ct_cache
+
+        post_migrate.connect(clear_ct_cache)
         if settings.GUARDIAN_MONKEY_PATCH_GROUP:
             monkey_patch_group()
         if settings.GUARDIAN_MONKEY_PATCH_USER:

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -47,9 +47,15 @@ from guardian.utils import (
 
 
 @lru_cache(None)
-def _get_ct_cached(app_label, codename):
+def _get_ct_cached(app_label: str, codename: str) -> ContentType:
     """Caches `ContentType` instances like its `QuerySet` does."""
     return ContentType.objects.get(app_label=app_label, permission__codename=codename)
+
+
+# kwargs are required to be connected to a django signal
+def clear_ct_cache(**kwargs) -> None:
+    """Helper to clear cache of `_get_ct_cached`"""
+    _get_ct_cached.cache_clear()
 
 
 def _get_first(t):


### PR DESCRIPTION
Like django does in `contenttype` app, this adds a simple and easy method to clear the cache which is used by the shortcuts module and register a signal receiver for `post_migrate` which resets that.