### PR TITLE
Fixed issue causing prefetch_perms() to throw when passed an empty list

### DIFF
--- a/guardian/core.py
+++ b/guardian/core.py
@@ -17,6 +17,10 @@ def _get_pks_model_and_ctype(objects):
     Assumes that all objects are of the same content type.
     """
 
+    model = None
+    ctype = None
+    pks = None
+
     if isinstance(objects, QuerySet):
         model = objects.model
         pks = [force_str(pk) for pk in objects.values_list("pk", flat=True)]


### PR DESCRIPTION
If you run the following code

```python
checker = ObjectPermissionChecker(user)
checker.prefetch_perms([])
```

The error `UnboundLocalError: local variable 'model' referenced before assignment` is thrown.

This PR addresses that issue by defining `model` `ctype` and `pks` at the top of `_get_pks_model_and_ctype`

Closes #519