### PR TITLE
[#933] Fix arg typing in get_perms_for_model

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -260,7 +260,7 @@ def get_group_perms(user_or_group: Any, obj: Model) -> QuerySet[Permission]:
     return check.get_group_perms(obj)
 
 
-def get_perms_for_model(cls: Type[Model]) -> QuerySet:
+def get_perms_for_model(cls: Type[Model] | str) -> QuerySet:
     """Get all permissions for a given model class.
 
     Returns:

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -260,7 +260,7 @@ def get_group_perms(user_or_group: Any, obj: Model) -> QuerySet[Permission]:
     return check.get_group_perms(obj)
 
 
-def get_perms_for_model(cls: Type[Model] | Model | str) -> QuerySet:
+def get_perms_for_model(cls: Union[Type[Model], Model, str]) -> QuerySet:
     """Get all permissions for a given model class.
 
     Returns:

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -260,7 +260,7 @@ def get_group_perms(user_or_group: Any, obj: Model) -> QuerySet[Permission]:
     return check.get_group_perms(obj)
 
 
-def get_perms_for_model(cls: Model) -> QuerySet:
+def get_perms_for_model(cls: Type[Model]) -> QuerySet:
     """Get all permissions for a given model class.
 
     Returns:

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -260,7 +260,7 @@ def get_group_perms(user_or_group: Any, obj: Model) -> QuerySet[Permission]:
     return check.get_group_perms(obj)
 
 
-def get_perms_for_model(cls: Type[Model] | str) -> QuerySet:
+def get_perms_for_model(cls: Type[Model] | Model | str) -> QuerySet:
     """Get all permissions for a given model class.
 
     Returns:


### PR DESCRIPTION
This PR address #933 by fixing the arg typing of `guardian.shortcuts.get_perms_for_model`, which was incorrectly typed as a model object instead of class.
