### PR TITLE
make shortcuts.assign_perm idempotent when doing bulk operations

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -150,10 +150,10 @@ def assign_perm(
     if isinstance(user_or_group, (QuerySet, list)):
         if user:
             model = get_user_obj_perms_model(obj)
-            return model.objects.assign_perm_to_many(perm, user, obj)
+            return model.objects.assign_perm_to_many(perm, user, obj, ignore_conflicts=True)
         if group:
             model = get_group_obj_perms_model(obj)
-            return model.objects.assign_perm_to_many(perm, group, obj)
+            return model.objects.assign_perm_to_many(perm, group, obj, ignore_conflicts=True)
 
     if user:
         model = get_user_obj_perms_model(obj)

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -81,6 +81,11 @@ class AssignPermTest(ObjectPermissionTestCase):
         self.assertTrue(self.user.has_perm("change_contenttype", self.ctype))
         self.assertTrue(self.user.has_perm("delete_contenttype", self.ctype))
 
+    def test_user_assign_perm_twice(self):
+        assign_perm("add_contenttype", self.user, self.ctype)
+        assign_perm("add_contenttype", self.user, self.ctype)
+        self.assertTrue(self.user.has_perm("add_contenttype", self.ctype))
+
     def test_group_assign_perm(self):
         assign_perm("add_contenttype", self.group, self.ctype)
         assign_perm("change_contenttype", self.group, self.ctype)
@@ -90,6 +95,13 @@ class AssignPermTest(ObjectPermissionTestCase):
         self.assertTrue(check.has_perm("add_contenttype", self.ctype))
         self.assertTrue(check.has_perm("change_contenttype", self.ctype))
         self.assertTrue(check.has_perm("delete_contenttype", self.ctype))
+
+    def test_group_assign_perm_twice(self):
+        assign_perm("add_contenttype", self.group, self.ctype)
+        assign_perm("add_contenttype", self.group, self.ctype)
+
+        check = ObjectPermissionChecker(self.group)
+        self.assertTrue(check.has_perm("add_contenttype", self.ctype))
 
     def test_user_assign_perm_queryset(self):
         assign_perm("add_contenttype", self.user, self.ctype_qset)
@@ -202,6 +214,12 @@ class MultipleIdentitiesOperationsTest(ObjectPermissionTestCase):
             self.assertTrue(user.has_perm("add_contenttype", self.ctype))
             self.assertTrue(user.has_perm("delete_contenttype", self.ctype))
 
+    def test_assign_to_many_users_twice(self):
+        assign_perm("add_contenttype", self.users_list, self.ctype)
+        assign_perm("add_contenttype", self.users_list, self.ctype)
+        for user in self.users_list:
+            self.assertTrue(user.has_perm("add_contenttype", self.ctype))
+
     def test_assign_to_many_groups_queryset(self):
         assign_perm("add_contenttype", self.groups_qs, self.ctype)
         assign_perm(self.get_permission("delete_contenttype"), self.groups_qs, self.ctype)
@@ -215,6 +233,12 @@ class MultipleIdentitiesOperationsTest(ObjectPermissionTestCase):
         for user in self.users_list:
             self.assertTrue(user.has_perm("add_contenttype", self.ctype))
             self.assertTrue(user.has_perm("delete_contenttype", self.ctype))
+
+    def test_assign_to_many_groups_twice(self):
+        assign_perm("add_contenttype", self.groups_list, self.ctype)
+        assign_perm("add_contenttype", self.groups_list, self.ctype)
+        for user in self.users_list:
+            self.assertTrue(user.has_perm("add_contenttype", self.ctype))
 
     def test_assign_to_multiple_identity_and_obj(self):
         with self.assertRaises(MultipleIdentityAndObjectError):


### PR DESCRIPTION
matching the behaviour observed when assigning them one-by-one

previously, passing a list or queryset into shortcuts.assign_perm could throw if the user or group already had the permission granted.