### PR TITLE
DO NOT MERGE - Updates to inactive user filtering

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -281,3 +281,61 @@ GroupObjectPermission = get_user_obj_perms_model()
 ```
 
 Defaults to `'guardian.GroupObjectPermission'`.
+
+## `GUARDIAN_WORK_ONLY_ACTIVE_USERS`
+
+!!! abstract "Added in version 2.4.0"
+
+When set to `True`, functions that return users with permissions (like
+`get_users_with_perms`) will only return active users (`is_active=True`).
+This filter applies to all permission-related functions that retrieve users,
+including direct user permissions, group permissions, and superuser permissions.
+
+This setting is particularly useful in applications where inactive users should
+not be considered when retrieving users with permissions, even if they technically
+still have permission assignments in the database.
+
+```python
+# Default behavior - return all users with permissions
+GUARDIAN_WORK_ONLY_ACTIVE_USERS = False
+
+# Only return active users with permissions
+GUARDIAN_WORK_ONLY_ACTIVE_USERS = True
+```
+
+!!! example "Usage example"
+
+    ```python
+    from guardian.shortcuts import get_users_with_perms, assign_perm
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+
+    # Create users
+    active_user = User.objects.create_user('active', is_active=True)
+    inactive_user = User.objects.create_user('inactive', is_active=False)
+
+    # Assign permissions to both users
+    assign_perm('change_model', active_user, my_object)
+    assign_perm('change_model', inactive_user, my_object)
+
+    # With GUARDIAN_WORK_ONLY_ACTIVE_USERS = False (default)
+    users = get_users_with_perms(my_object)  # Returns both users
+
+    # With GUARDIAN_WORK_ONLY_ACTIVE_USERS = True
+    users = get_users_with_perms(my_object)  # Returns only active_user
+    ```
+
+!!! tip "Performance consideration"
+
+    This setting adds a filter to the database query, so there is a minimal
+    performance impact. However, the benefit of filtering out inactive users
+    often outweighs this small overhead.
+
+!!! warning "Backward compatibility"
+
+    Existing permission assignments for inactive users remain in the database
+    and are not automatically removed. This setting only affects the retrieval
+    of users, not the permission assignments themselves.
+
+Defaults to `False`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -286,8 +286,9 @@ Defaults to `'guardian.GroupObjectPermission'`.
 
 !!! abstract "Added in version 3.3.0"
 
-When set to `True`, functions that return users with permissions (like
-`get_users_with_perms`) will only return active users (`is_active=True`).
+When set to `True`, functions like `get_users_with_perms` will only return
+active users (`is_active=True`), and `get_objects_for_user` will return an
+empty queryset for inactive users.
 This filter applies to all permission-related functions that retrieve users,
 including direct user permissions, group permissions, and superuser permissions.
 
@@ -324,6 +325,13 @@ GUARDIAN_ACTIVE_USERS_ONLY = True
 
     # With GUARDIAN_ACTIVE_USERS_ONLY = True
     users = get_users_with_perms(my_object)  # Returns only active_user
+
+    # get_objects_for_user also respects the setting
+    from guardian.shortcuts import get_objects_for_user
+
+    # With GUARDIAN_ACTIVE_USERS_ONLY = True
+    objects = get_objects_for_user(inactive_user, 'change_model', MyModel)  # Returns empty queryset
+    objects = get_objects_for_user(active_user, 'change_model', MyModel)    # Returns objects normally
     ```
 
 !!! tip "Performance consideration"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -284,7 +284,7 @@ Defaults to `'guardian.GroupObjectPermission'`.
 
 ## `GUARDIAN_WORK_ONLY_ACTIVE_USERS`
 
-!!! abstract "Added in version 2.4.0"
+!!! abstract "Added in version 3.2.0"
 
 When set to `True`, functions that return users with permissions (like
 `get_users_with_perms`) will only return active users (`is_active=True`).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -346,4 +346,10 @@ GUARDIAN_ACTIVE_USERS_ONLY = True
     and are not automatically removed. This setting only affects the retrieval
     of users, not the permission assignments themselves.
 
+!!! warning "Custom user models"
+
+    This setting requires the user model to have an `is_active` field.
+    If the user model does not have an `is_active` field, the setting will
+    have no effect and a system check warning (`guardian.W002`) will be raised.
+
 Defaults to `False`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -284,7 +284,7 @@ Defaults to `'guardian.GroupObjectPermission'`.
 
 ## `GUARDIAN_ACTIVE_USERS_ONLY`
 
-!!! abstract "Added in version 3.2.0"
+!!! abstract "Added in version 3.3.0"
 
 When set to `True`, functions that return users with permissions (like
 `get_users_with_perms`) will only return active users (`is_active=True`).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -282,7 +282,7 @@ GroupObjectPermission = get_user_obj_perms_model()
 
 Defaults to `'guardian.GroupObjectPermission'`.
 
-## `GUARDIAN_WORK_ONLY_ACTIVE_USERS`
+## `GUARDIAN_ACTIVE_USERS_ONLY`
 
 !!! abstract "Added in version 3.2.0"
 
@@ -297,10 +297,10 @@ still have permission assignments in the database.
 
 ```python
 # Default behavior - return all users with permissions
-GUARDIAN_WORK_ONLY_ACTIVE_USERS = False
+GUARDIAN_ACTIVE_USERS_ONLY = False
 
 # Only return active users with permissions
-GUARDIAN_WORK_ONLY_ACTIVE_USERS = True
+GUARDIAN_ACTIVE_USERS_ONLY = True
 ```
 
 !!! example "Usage example"
@@ -319,10 +319,10 @@ GUARDIAN_WORK_ONLY_ACTIVE_USERS = True
     assign_perm('change_model', active_user, my_object)
     assign_perm('change_model', inactive_user, my_object)
 
-    # With GUARDIAN_WORK_ONLY_ACTIVE_USERS = False (default)
+    # With GUARDIAN_ACTIVE_USERS_ONLY = False (default)
     users = get_users_with_perms(my_object)  # Returns both users
 
-    # With GUARDIAN_WORK_ONLY_ACTIVE_USERS = True
+    # With GUARDIAN_ACTIVE_USERS_ONLY = True
     users = get_users_with_perms(my_object)  # Returns only active_user
     ```
 

--- a/guardian/checks.py
+++ b/guardian/checks.py
@@ -1,5 +1,16 @@
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core.checks import Tags, Warning, register
+from django.core.exceptions import FieldDoesNotExist
+
+
+def _user_model_has_is_active_field() -> bool:
+    """Check whether the current user model has an ``is_active`` field."""
+    try:
+        get_user_model()._meta.get_field("is_active")
+        return True
+    except FieldDoesNotExist:
+        return False
 
 
 # noinspection PyUnusedLocal
@@ -18,4 +29,18 @@ def check_settings(app_configs, **kwargs):
             "'guardian.backends.ObjectPermissionBackend')`."
         )
         checks.append(Warning(msg, id="guardian.W001"))
+    return checks
+
+
+@register(Tags.compatibility)
+def check_active_users_only(app_configs, **kwargs):
+    checks = []
+    if getattr(settings, "GUARDIAN_ACTIVE_USERS_ONLY", False) and not _user_model_has_is_active_field():
+        checks.append(
+            Warning(
+                "GUARDIAN_ACTIVE_USERS_ONLY is enabled but the user model "
+                "does not have an 'is_active' field. The setting will have no effect.",
+                id="guardian.W002",
+            )
+        )
     return checks

--- a/guardian/conf/settings.py
+++ b/guardian/conf/settings.py
@@ -51,7 +51,7 @@ USER_OBJ_PERMS_MODEL = getattr(settings, "GUARDIAN_USER_OBJ_PERMS_MODEL", "guard
 GROUP_OBJ_PERMS_MODEL = getattr(settings, "GUARDIAN_GROUP_OBJ_PERMS_MODEL", "guardian.GroupObjectPermission")
 
 # Only work with active users when retrieving users with permissions
-WORK_ONLY_ACTIVE_USERS = getattr(settings, "GUARDIAN_WORK_ONLY_ACTIVE_USERS", False)
+ACTIVE_USERS_ONLY = getattr(settings, "GUARDIAN_ACTIVE_USERS_ONLY", False)
 
 
 def check_configuration():

--- a/guardian/conf/settings.py
+++ b/guardian/conf/settings.py
@@ -50,6 +50,9 @@ ANONYMOUS_USER_CACHE_TTL = getattr(settings, "GUARDIAN_ANONYMOUS_USER_CACHE_TTL"
 USER_OBJ_PERMS_MODEL = getattr(settings, "GUARDIAN_USER_OBJ_PERMS_MODEL", "guardian.UserObjectPermission")
 GROUP_OBJ_PERMS_MODEL = getattr(settings, "GUARDIAN_GROUP_OBJ_PERMS_MODEL", "guardian.GroupObjectPermission")
 
+# Only work with active users when retrieving users with permissions
+WORK_ONLY_ACTIVE_USERS = getattr(settings, "GUARDIAN_WORK_ONLY_ACTIVE_USERS", False)
+
 
 def check_configuration():
     if RENDER_403 and RAISE_403:

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -73,7 +73,7 @@ class ObjectPermissionChecker:
         Returns:
             True if user/group has the permission, False otherwise
         """
-        if self.user and not getattr(self.user, "is_active", True):
+        if guardian_settings.ACTIVE_USERS_ONLY and self.user and not getattr(self.user, "is_active", True):
             return False
         elif self.user and self.user.is_superuser:
             return True
@@ -123,7 +123,7 @@ class ObjectPermissionChecker:
         return user_filters
 
     def get_user_perms(self, obj: Model) -> QuerySet[Permission]:
-        if self.user and not getattr(self.user, "is_active", True):
+        if guardian_settings.ACTIVE_USERS_ONLY and self.user and not getattr(self.user, "is_active", True):
             return Permission.objects.none().values_list("codename", flat=True)
 
         ctype = get_content_type(obj)
@@ -136,7 +136,7 @@ class ObjectPermissionChecker:
         return user_perms
 
     def get_group_perms(self, obj: Model) -> QuerySet[Permission]:
-        if self.user and not getattr(self.user, "is_active", True):
+        if guardian_settings.ACTIVE_USERS_ONLY and self.user and not getattr(self.user, "is_active", True):
             return Permission.objects.none().values_list("codename", flat=True)
 
         ctype = get_content_type(obj)
@@ -157,7 +157,7 @@ class ObjectPermissionChecker:
         Returns:
             list of codenames for all permissions for given `obj`.
         """
-        if self.user and not getattr(self.user, "is_active", True):
+        if guardian_settings.ACTIVE_USERS_ONLY and self.user and not getattr(self.user, "is_active", True):
             return []
 
         if guardian_settings.AUTO_PREFETCH:
@@ -195,7 +195,7 @@ class ObjectPermissionChecker:
         Parameters:
             objects (list[Model]): Iterable of Django model objects.
         """
-        if self.user and not getattr(self.user, "is_active", True):
+        if guardian_settings.ACTIVE_USERS_ONLY and self.user and not getattr(self.user, "is_active", True):
             return []
 
         pks, model, ctype = _get_pks_model_and_ctype(objects)

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -73,7 +73,7 @@ class ObjectPermissionChecker:
         Returns:
             True if user/group has the permission, False otherwise
         """
-        if self.user and not self.user.is_active:
+        if self.user and not getattr(self.user, "is_active", True):
             return False
         elif self.user and self.user.is_superuser:
             return True
@@ -123,7 +123,7 @@ class ObjectPermissionChecker:
         return user_filters
 
     def get_user_perms(self, obj: Model) -> QuerySet[Permission]:
-        if self.user and not self.user.is_active:
+        if self.user and not getattr(self.user, "is_active", True):
             return Permission.objects.none().values_list("codename", flat=True)
 
         ctype = get_content_type(obj)
@@ -136,7 +136,7 @@ class ObjectPermissionChecker:
         return user_perms
 
     def get_group_perms(self, obj: Model) -> QuerySet[Permission]:
-        if self.user and not self.user.is_active:
+        if self.user and not getattr(self.user, "is_active", True):
             return Permission.objects.none().values_list("codename", flat=True)
 
         ctype = get_content_type(obj)
@@ -157,7 +157,7 @@ class ObjectPermissionChecker:
         Returns:
             list of codenames for all permissions for given `obj`.
         """
-        if self.user and not self.user.is_active:
+        if self.user and not getattr(self.user, "is_active", True):
             return []
 
         if guardian_settings.AUTO_PREFETCH:
@@ -195,7 +195,7 @@ class ObjectPermissionChecker:
         Parameters:
             objects (list[Model]): Iterable of Django model objects.
         """
-        if self.user and not self.user.is_active:
+        if self.user and not getattr(self.user, "is_active", True):
             return []
 
         pks, model, ctype = _get_pks_model_and_ctype(objects)

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -397,7 +397,7 @@ def get_users_with_perms(
         if with_superusers:
             qset = qset | Q(is_superuser=True)
         queryset = get_user_model().objects.filter(qset)
-        if getattr(settings, "GUARDIAN_WORK_ONLY_ACTIVE_USERS", False):
+        if getattr(settings, "GUARDIAN_ACTIVE_USERS_ONLY", False):
             queryset = queryset.filter(is_active=True)
         return queryset.distinct()
     else:

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -635,6 +635,10 @@ def get_objects_for_user(
     # match which means: ctype.model_class() == queryset.model
     # we should also have `codenames` list
 
+    # Check if active user filtering is set and user is inactive
+    if guardian_settings.ACTIVE_USERS_ONLY and not user.is_active:
+        return queryset.none()
+
     # First check if user is superuser and if so, return queryset immediately
     if with_superuser and user.is_superuser:
         return queryset

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, Type, TypeVar, Union
 import warnings
 
 from django.apps import apps
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
@@ -395,7 +396,10 @@ def get_users_with_perms(
             qset = qset | Q(groups__in=group_ids)
         if with_superusers:
             qset = qset | Q(is_superuser=True)
-        return get_user_model().objects.filter(qset).distinct()
+        queryset = get_user_model().objects.filter(qset)
+        if getattr(settings, "GUARDIAN_WORK_ONLY_ACTIVE_USERS", False):
+            queryset = queryset.filter(is_active=True)
+        return queryset.distinct()
     else:
         # TODO: Do not hit db for each user!
         users = {}

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -7,7 +7,6 @@ from typing import Any, Optional, Type, TypeVar, Union
 import warnings
 
 from django.apps import apps
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
@@ -32,6 +31,7 @@ from django.db.models.expressions import Value
 from django.db.models.functions import Cast, Replace
 from django.shortcuts import _get_queryset
 
+from guardian.conf import settings as guardian_settings
 from guardian.core import ObjectPermissionChecker
 from guardian.ctypes import get_content_type
 from guardian.exceptions import (
@@ -397,7 +397,7 @@ def get_users_with_perms(
         if with_superusers:
             qset = qset | Q(is_superuser=True)
         queryset = get_user_model().objects.filter(qset)
-        if getattr(settings, "GUARDIAN_ACTIVE_USERS_ONLY", False):
+        if guardian_settings.ACTIVE_USERS_ONLY:
             queryset = queryset.filter(is_active=True)
         return queryset.distinct()
     else:

--- a/guardian/testapp/tests/test_checks.py
+++ b/guardian/testapp/tests/test_checks.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
+from django.core.exceptions import FieldDoesNotExist
 from django.test import TestCase
 
-from guardian.checks import check_settings
+from guardian.checks import check_active_users_only, check_settings
 
 
 class SystemCheckTestCase(TestCase):
@@ -14,3 +17,31 @@ class SystemCheckTestCase(TestCase):
             AUTHENTICATION_BACKENDS=("django.contrib.auth.backends.ModelBackend",),
         ):
             self.assertEqual(len(check_settings(None)), 1)
+
+
+class ActiveUsersOnlyCheckTestCase(TestCase):
+    def test_no_warning_when_setting_disabled(self):
+        with self.settings(GUARDIAN_ACTIVE_USERS_ONLY=False):
+            result = check_active_users_only(None)
+            self.assertEqual(result, [])
+
+    def test_no_warning_when_user_model_has_is_active(self):
+        with self.settings(GUARDIAN_ACTIVE_USERS_ONLY=True):
+            result = check_active_users_only(None)
+            self.assertEqual(result, [])
+
+    def test_warning_when_user_model_lacks_is_active(self):
+        def fake_get_field(name):
+            if name == "is_active":
+                raise FieldDoesNotExist()
+            return original_get_field(name)
+
+        from django.contrib.auth import get_user_model
+
+        original_get_field = get_user_model()._meta.get_field
+
+        with self.settings(GUARDIAN_ACTIVE_USERS_ONLY=True):
+            with patch.object(type(get_user_model()._meta), "get_field", side_effect=fake_get_field):
+                result = check_active_users_only(None)
+                self.assertEqual(len(result), 1)
+                self.assertEqual(result[0].id, "guardian.W002")

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -641,7 +641,7 @@ class GetUsersWithPermsTest(TestCase):
         expected = [admin]
         self.assertEqual(set(result), set(expected))
 
-    def test_work_only_active_users_default_behavior(self):
+    def test_active_users_only_default_behavior(self):
         """Test that by default both active and inactive users are returned."""
         # Create inactive user
         inactive_user = User.objects.create(username="inactive_user", is_active=False)
@@ -658,9 +658,9 @@ class GetUsersWithPermsTest(TestCase):
         self.assertIn(inactive_user.username, result_usernames)
         self.assertEqual(len(result), 2)
 
-    @override_settings(GUARDIAN_WORK_ONLY_ACTIVE_USERS=True)
-    def test_work_only_active_users_enabled(self):
-        """Test that only active users are returned when GUARDIAN_WORK_ONLY_ACTIVE_USERS=True."""
+    @override_settings(GUARDIAN_ACTIVE_USERS_ONLY=True)
+    def test_active_users_only_enabled(self):
+        """Test that only active users are returned when GUARDIAN_ACTIVE_USERS_ONLY=True."""
         # Create inactive user
         inactive_user = User.objects.create(username="inactive_user", is_active=False)
 
@@ -676,8 +676,8 @@ class GetUsersWithPermsTest(TestCase):
         self.assertNotIn(inactive_user.username, result_usernames)
         self.assertEqual(len(result), 1)
 
-    @override_settings(GUARDIAN_WORK_ONLY_ACTIVE_USERS=True)
-    def test_work_only_active_users_with_groups(self):
+    @override_settings(GUARDIAN_ACTIVE_USERS_ONLY=True)
+    def test_active_users_only_with_groups(self):
         """Test that inactive users are filtered even when they have group permissions."""
         # Create inactive user and add to group
         inactive_user = User.objects.create(username="inactive_user", is_active=False)
@@ -695,8 +695,8 @@ class GetUsersWithPermsTest(TestCase):
         self.assertNotIn(inactive_user.username, result_usernames)
         self.assertEqual(len(result), 1)
 
-    @override_settings(GUARDIAN_WORK_ONLY_ACTIVE_USERS=True)
-    def test_work_only_active_users_with_superuser(self):
+    @override_settings(GUARDIAN_ACTIVE_USERS_ONLY=True)
+    def test_active_users_only_with_superuser(self):
         """Test that inactive superusers are also filtered out."""
         # Create inactive superuser
         inactive_superuser = User.objects.create(username="inactive_super", is_superuser=True, is_active=False)
@@ -710,8 +710,8 @@ class GetUsersWithPermsTest(TestCase):
         self.assertNotIn(inactive_superuser.username, result_usernames)
         self.assertEqual(len(result), 1)
 
-    @override_settings(GUARDIAN_WORK_ONLY_ACTIVE_USERS=True)
-    def test_work_only_active_users_attach_perms(self):
+    @override_settings(GUARDIAN_ACTIVE_USERS_ONLY=True)
+    def test_active_users_only_attach_perms(self):
         """Test that inactive users are filtered when attach_perms=True."""
         # Create inactive user
         inactive_user = User.objects.create(username="inactive_user", is_active=False)
@@ -727,8 +727,8 @@ class GetUsersWithPermsTest(TestCase):
         self.assertNotIn(inactive_user, result.keys())
         self.assertEqual(len(result), 1)
 
-    @override_settings(GUARDIAN_WORK_ONLY_ACTIVE_USERS=True)
-    def test_work_only_active_users_with_group_users_false(self):
+    @override_settings(GUARDIAN_ACTIVE_USERS_ONLY=True)
+    def test_active_users_only_with_group_users_false(self):
         """Test that inactive users with direct permissions are filtered when with_group_users=False."""
         # Create inactive user with direct permission
         inactive_user = User.objects.create(username="inactive_user", is_active=False)

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.query import QuerySet
-from django.test import TestCase, TransactionTestCase, override_settings
+from django.test import TestCase, TransactionTestCase
 
 from guardian.compat import get_user_permission_full_codename
 from guardian.core import ObjectPermissionChecker
@@ -658,7 +658,7 @@ class GetUsersWithPermsTest(TestCase):
         self.assertIn(inactive_user.username, result_usernames)
         self.assertEqual(len(result), 2)
 
-    @override_settings(GUARDIAN_ACTIVE_USERS_ONLY=True)
+    @mock.patch("guardian.conf.settings.ACTIVE_USERS_ONLY", True)
     def test_active_users_only_enabled(self):
         """Test that only active users are returned when GUARDIAN_ACTIVE_USERS_ONLY=True."""
         # Create inactive user
@@ -676,7 +676,7 @@ class GetUsersWithPermsTest(TestCase):
         self.assertNotIn(inactive_user.username, result_usernames)
         self.assertEqual(len(result), 1)
 
-    @override_settings(GUARDIAN_ACTIVE_USERS_ONLY=True)
+    @mock.patch("guardian.conf.settings.ACTIVE_USERS_ONLY", True)
     def test_active_users_only_with_groups(self):
         """Test that inactive users are filtered even when they have group permissions."""
         # Create inactive user and add to group
@@ -695,7 +695,7 @@ class GetUsersWithPermsTest(TestCase):
         self.assertNotIn(inactive_user.username, result_usernames)
         self.assertEqual(len(result), 1)
 
-    @override_settings(GUARDIAN_ACTIVE_USERS_ONLY=True)
+    @mock.patch("guardian.conf.settings.ACTIVE_USERS_ONLY", True)
     def test_active_users_only_with_superuser(self):
         """Test that inactive superusers are also filtered out."""
         # Create inactive superuser
@@ -710,7 +710,7 @@ class GetUsersWithPermsTest(TestCase):
         self.assertNotIn(inactive_superuser.username, result_usernames)
         self.assertEqual(len(result), 1)
 
-    @override_settings(GUARDIAN_ACTIVE_USERS_ONLY=True)
+    @mock.patch("guardian.conf.settings.ACTIVE_USERS_ONLY", True)
     def test_active_users_only_attach_perms(self):
         """Test that inactive users are filtered when attach_perms=True."""
         # Create inactive user
@@ -727,7 +727,7 @@ class GetUsersWithPermsTest(TestCase):
         self.assertNotIn(inactive_user, result.keys())
         self.assertEqual(len(result), 1)
 
-    @override_settings(GUARDIAN_ACTIVE_USERS_ONLY=True)
+    @mock.patch("guardian.conf.settings.ACTIVE_USERS_ONLY", True)
     def test_active_users_only_with_group_users_false(self):
         """Test that inactive users with direct permissions are filtered when with_group_users=False."""
         # Create inactive user with direct permission


### PR DESCRIPTION
## TLDR

This is an unholy beast of a PR. Please let us not merge this.

## Summary

This PR builds on @Natgho 's contribution in #952, which in turn builds on the bug noted by @raphaelmerx in #854.

[Here](https://github.com/django-guardian/django-guardian/pull/854#discussion_r1986917346), @BonaFideIT suggests some sensible basic requirements:
- introduce a settings that allows activation of the behaviour
- add a check if the user model has the property "is_active"
- add a warning if the setting is used and is_active is not present.

So, I did a deep dive into consistency with results reported [here](https://github.com/django-guardian/django-guardian/pull/952#pullrequestreview-3848826619). Between us, @Natgho and I have implemented the above, whilst making every permission check consistent in behaviour with respect to `user.is_active`.

Unfortunately, **either** we accept inconsistency in behaviour across the various checks, **or** we need a breaking change.

### ⚠️ 💥 Breaking change is required 

Previously, `has_perm()`, `get_perms()`, etc. **unconditionally** returned empty results for inactive users, whilst other check tools like the shortcuts **did not**, as @raphaelmerx pointed out.

In this PR, with the newly added setting `GUARDIAN_ACTIVE_USERS_ONLY=False` (the default), inactive users are no longer blocked by ObjectPermissionChecker. Now, that behavior only happens when `GUARDIAN_ACTIVE_USERS_ONLY=True`. The entire inactive-user filtering story is now controlled by a single setting, consistently across all APIs.

The alternative was to set `GUARDIAN_ACTIVE_USERS_ONLY=True` by default, which maintains compatibility on the `ObjectPermissionChecker` level but breaks it on the shortcuts in exactly the same way as the original PR.

Whilst this works, there is a hell of a lot of code here, a ton of edge cases, a lot of extra logic... __*all for a feature nobody asked for*__ - even the originator just wanted consistent behaviour with `has_perm`, they didn't need to control the `is_active` behaviour -- that's just something we cooked up to avoid making a breaking change.

### Other notes

- guardian already presupposes `is_active` on a user model ([f.ex here](https://github.com/django-guardian/django-guardian/blob/77c7a8b666321900309212d73c36d68fb5789aef/guardian/core.py#L76)) so it's not actually breaking to continue using it (although in this PR for the sake of form, I checked for its presence).

## API Consistency and Suggested Alternative

It's taken five hours to build this plus whatever time @Natgho spent... I really don't want to spend  the next five years maintaining it. 

**Long term, I don't believe Guardian will be well served by inconsistent behaviour in the API. so I don't think that we should accept inconsistency to avoid a breaking change.**

So, given that we have to make a breaking change anyway I recommend that we basically implement Raphael's suggestion in all cases (inactive users never given permission, not adjustable), ensure that's part of all the shortcuts uniformly... then release that as part of Version 4.