### PR TITLE
Add sections to docs for minor improvements and clarifications

### DIFF
--- a/docs/userguide/performance.md
+++ b/docs/userguide/performance.md
@@ -81,15 +81,26 @@ class Project(models.Model):
     name = models.CharField(max_length=128, unique=True)
 
 class ProjectUserObjectPermission(UserObjectPermissionBase):
-    content_object = models.ForeignKey(Project, on_delete=models.CASCADE)
+    content_object = models.ForeignKey(
+        Project, on_delete=models.CASCADE, related_name='user_object_permissions'
+    )
 
 class ProjectGroupObjectPermission(GroupObjectPermissionBase):
-    content_object = models.ForeignKey(Project, on_delete=models.CASCADE)
+    content_object = models.ForeignKey(
+        Project, on_delete=models.CASCADE, related_name='group_object_permissions'
+    )
 ```
 
 !!! danger "Important"
     Name of the `ForeignKey` field is important and it should be
     `content_object` as underlying queries depends on it.
+
+!!! warning "Reverse accessor clashes"
+    If `content_object` points to the same model as the inherited `user`
+    or `group` foreign key (e.g., you are assigning permissions on a custom
+    User model), Django will raise a reverse accessor clash error. To fix
+    this, set a unique `related_name` on the `content_object` field as
+    shown in the example above.
 
 From now on, `guardian` will figure out that `Project` model has direct
 relation for user/group object permissions and will use those models. It

--- a/docs/userguide/signals.md
+++ b/docs/userguide/signals.md
@@ -28,8 +28,13 @@ class MyAppConfig(AppConfig):
     name = "myapp"
 
     def ready(self):
-        from guardian.models import UserObjectPermission, GroupObjectPermission
+        from guardian.utils import (
+            get_user_obj_perms_model,
+            get_group_obj_perms_model,
+        )
 
+        UserObjectPermission = get_user_obj_perms_model()
+        GroupObjectPermission = get_group_obj_perms_model()
         post_save.connect(
             self.handle_perm_change,
             sender=UserObjectPermission,

--- a/docs/userguide/signals.md
+++ b/docs/userguide/signals.md
@@ -30,10 +30,26 @@ class MyAppConfig(AppConfig):
     def ready(self):
         from guardian.models import UserObjectPermission, GroupObjectPermission
 
-        post_save.connect(self.handle_perm_change, sender=UserObjectPermission)
-        post_save.connect(self.handle_perm_change, sender=GroupObjectPermission)
-        post_delete.connect(self.handle_perm_change, sender=UserObjectPermission)
-        post_delete.connect(self.handle_perm_change, sender=GroupObjectPermission)
+        post_save.connect(
+            self.handle_perm_change,
+            sender=UserObjectPermission,
+            dispatch_uid="myapp.handle_perm_change.userobjectpermission.post_save",
+        )
+        post_save.connect(
+            self.handle_perm_change,
+            sender=GroupObjectPermission,
+            dispatch_uid="myapp.handle_perm_change.groupobjectpermission.post_save",
+        )
+        post_delete.connect(
+            self.handle_perm_change,
+            sender=UserObjectPermission,
+            dispatch_uid="myapp.handle_perm_change.userobjectpermission.post_delete",
+        )
+        post_delete.connect(
+            self.handle_perm_change,
+            sender=GroupObjectPermission,
+            dispatch_uid="myapp.handle_perm_change.groupobjectpermission.post_delete",
+        )
 
     @staticmethod
     def handle_perm_change(sender, instance, **kwargs):

--- a/docs/userguide/signals.md
+++ b/docs/userguide/signals.md
@@ -1,0 +1,57 @@
+---
+title: Signals
+description: How to react to object permission changes using Django signals.
+---
+
+# Reacting to Permission Changes with Signals
+
+Django Guardian does not currently ship dedicated signals for permission changes.
+However, you can use Django's built-in `post_save` and `post_delete` signals on
+Guardian's permission models to react when object permissions are created or
+removed.
+
+## Connecting to Permission Model Signals
+
+Guardian stores object permissions in `UserObjectPermission` and
+`GroupObjectPermission` models (or your custom replacements). Because these are
+regular Django models, you can connect to their `post_save` and `post_delete`
+signals just like any other model.
+
+Wire the signals inside your `AppConfig.ready()` method:
+
+``` python
+from django.apps import AppConfig
+from django.db.models.signals import post_save, post_delete
+
+
+class MyAppConfig(AppConfig):
+    name = "myapp"
+
+    def ready(self):
+        from guardian.models import UserObjectPermission, GroupObjectPermission
+
+        post_save.connect(self.handle_perm_change, sender=UserObjectPermission)
+        post_save.connect(self.handle_perm_change, sender=GroupObjectPermission)
+        post_delete.connect(self.handle_perm_change, sender=UserObjectPermission)
+        post_delete.connect(self.handle_perm_change, sender=GroupObjectPermission)
+
+    @staticmethod
+    def handle_perm_change(sender, instance, **kwargs):
+        # React to the permission change here.
+        # For example: invalidate a cache, write an audit log, or send a
+        # notification.
+        print(f"Permission changed: {instance}")
+```
+
+!!! warning
+
+    **Bulk operations do not fire `post_save` signals.** Methods like
+    `bulk_assign_perm()` and `assign_perm_to_many()` use `bulk_create()`
+    internally, so per-object `post_save` signals are not sent. If you rely on
+    signals, assign permissions individually instead. See the
+    [Assign Object Permissions](assign.md#limitations) page for details.
+
+## Further Reading
+
+This pattern was originally discussed in
+[GitHub issue #805](https://github.com/django-guardian/django-guardian/issues/805).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - Custom Group Model: userguide/custom-group-model.md
       - Shortcuts: userguide/shortcuts.md
       - Admin Integration: userguide/admin-integration.md
+      - Signals: userguide/signals.md
   - Contributing:
       - Overview: develop/overview.md
       - Testing: develop/testing.md


### PR DESCRIPTION
## Summary

Adds sections to docs for minor improvements and clarifications:
 - Add reverse accessor clash warning and an easier default
 - Add a section on signals to show how to trigger on permission change