### PR TITLE
Improve managers typing and reduce code duplication

### DIFF
--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -1,7 +1,8 @@
-from typing import Any, Union
+from typing import Any, TypeAlias, Union
 import warnings
 
 from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models import Model, Q, QuerySet
@@ -9,6 +10,28 @@ from django.db.models import Model, Q, QuerySet
 from guardian.core import ObjectPermissionChecker
 from guardian.ctypes import get_content_type
 from guardian.exceptions import ObjectNotPersisted
+
+_PermType: TypeAlias = Union[Permission, str]
+
+
+def _ensure_permission(perm: _PermType, ctype: ContentType) -> Permission:
+    if isinstance(perm, str):
+        perm = Permission.objects.get(content_type=ctype, codename=perm)
+
+    return perm
+
+
+def _get_perm_filter(
+    perm: _PermType, model: Union[Model, type[Model], None] = None, ctype: Union[ContentType, None] = None
+) -> Q:
+    if isinstance(perm, Permission):
+        return Q(permission=perm)
+
+    assert ctype is not None or model is not None
+    if ctype is None and model is not None:
+        ctype = get_content_type(model)
+
+    return Q(permission__codename=perm, permission__content_type=ctype)
 
 
 class BaseObjectPermissionManager(models.Manager):
@@ -27,15 +50,12 @@ class BaseObjectPermissionManager(models.Manager):
         except FieldDoesNotExist:
             return False
 
-    def assign_perm(self, perm: str, user_or_group: Any, obj: Model) -> Any:
+    def assign_perm(self, perm: _PermType, user_or_group: Any, obj: Model) -> Any:
         """Assigns permission with given `perm` for an instance `obj` and `user`."""
         if getattr(obj, "pk", None) is None:
             raise ObjectNotPersisted("Object %s needs to be persisted first" % obj)
         ctype = get_content_type(obj)
-        if not isinstance(perm, Permission):
-            permission = Permission.objects.get(content_type=ctype, codename=perm)
-        else:
-            permission = perm
+        permission = _ensure_permission(perm, ctype)
 
         kwargs = {"permission": permission, self.user_or_group_field: user_or_group}
         if self.is_generic():
@@ -48,7 +68,7 @@ class BaseObjectPermissionManager(models.Manager):
         return obj_perm
 
     def bulk_assign_perm(
-        self, perm: str, user_or_group: Any, queryset: QuerySet, ignore_conflicts: bool = False
+        self, perm: _PermType, user_or_group: Any, queryset: Union[QuerySet, list], ignore_conflicts: bool = False
     ) -> Any:
         """
         Bulk assigns permissions with given `perm` for an objects in `queryset` and
@@ -59,11 +79,7 @@ class BaseObjectPermissionManager(models.Manager):
         else:
             ctype = get_content_type(queryset.model)
 
-        if not isinstance(perm, Permission):
-            permission = Permission.objects.get(content_type=ctype, codename=perm)
-        else:
-            permission = perm
-
+        permission = _ensure_permission(perm, ctype)
         checker = ObjectPermissionChecker(user_or_group)
         checker.prefetch_perms(queryset)
 
@@ -81,15 +97,14 @@ class BaseObjectPermissionManager(models.Manager):
 
         return assigned_perms
 
-    def assign_perm_to_many(self, perm: str, users_or_groups: Any, obj: Model, ignore_conflicts: bool = False) -> Any:
+    def assign_perm_to_many(
+        self, perm: _PermType, users_or_groups: Any, obj: Model, ignore_conflicts: bool = False
+    ) -> Any:
         """
         Bulk assigns given `perm` for the object `obj` to a set of users or a set of groups.
         """
         ctype = get_content_type(obj)
-        if not isinstance(perm, Permission):
-            permission = Permission.objects.get(content_type=ctype, codename=perm)
-        else:
-            permission = perm
+        permission = _ensure_permission(perm, ctype)
 
         kwargs = {"permission": permission}
         if self.is_generic():
@@ -106,7 +121,7 @@ class BaseObjectPermissionManager(models.Manager):
 
         return self.model.objects.bulk_create(to_add, ignore_conflicts=ignore_conflicts)
 
-    def assign(self, perm: str, user_or_group: Any, obj: Model) -> Any:
+    def assign(self, perm: _PermType, user_or_group: Any, obj: Model) -> Any:
         """Depreciated function name left in for compatibility"""
         warnings.warn(
             "UserObjectPermissionManager method 'assign' is being renamed to 'assign_perm'. Update your code accordingly as old name will be depreciated in 2.0 version.",
@@ -114,7 +129,7 @@ class BaseObjectPermissionManager(models.Manager):
         )
         return self.assign_perm(perm, user_or_group, obj)
 
-    def remove_perm(self, perm: str, user_or_group: Any, obj: Model) -> tuple[int, dict]:
+    def remove_perm(self, perm: _PermType, user_or_group: Any, obj: Model) -> tuple[int, dict]:
         """
         Removes permission `perm` for an instance `obj` and given `user_or_group`.
 
@@ -126,12 +141,7 @@ class BaseObjectPermissionManager(models.Manager):
             raise ObjectNotPersisted("Object %s needs to be persisted first" % obj)
 
         filters = Q(**{self.user_or_group_field: user_or_group})
-
-        if isinstance(perm, Permission):
-            filters &= Q(permission=perm)
-        else:
-            filters &= Q(permission__codename=perm, permission__content_type=get_content_type(obj))
-
+        filters &= _get_perm_filter(perm, model=obj)
         if self.is_generic():
             filters &= Q(object_pk=obj.pk)
         else:
@@ -139,7 +149,7 @@ class BaseObjectPermissionManager(models.Manager):
         return self.filter(filters).delete()
 
     def bulk_remove_perm(
-        self, perm: Union[str, Permission], user_or_group: Any, queryset: Union[QuerySet, list]
+        self, perm: _PermType, user_or_group: Any, queryset: Union[QuerySet, list]
     ) -> tuple[int, dict]:
         """
         Removes permission `perm` for a `queryset` and given `user_or_group`.
@@ -157,11 +167,7 @@ class BaseObjectPermissionManager(models.Manager):
         else:
             ctype = get_content_type(queryset.model)
 
-        if isinstance(perm, Permission):
-            filters &= Q(permission=perm)
-        else:
-            filters &= Q(permission__codename=perm, permission__content_type=ctype)
-
+        filters &= _get_perm_filter(perm, ctype=ctype)
         if self.is_generic():
             if isinstance(queryset, list):
                 filters &= Q(object_pk__in=[str(obj.pk) for obj in queryset])
@@ -172,15 +178,12 @@ class BaseObjectPermissionManager(models.Manager):
 
         return self.filter(filters).delete()
 
-    def remove_perm_from_many(self, perm: Union[str, Permission], users_or_groups: Any, obj: Model) -> tuple[int, dict]:
+    def remove_perm_from_many(self, perm: _PermType, users_or_groups: Any, obj: Model) -> tuple[int, dict]:
         """
         Bulk removes given `perm` for the object `obj` from a set of users or a set of groups.
         """
         ctype = get_content_type(obj)
-        if isinstance(perm, Permission):
-            filters = Q(permission=perm)
-        else:
-            filters = Q(permission__codename=perm, permission__content_type=ctype)
+        filters = _get_perm_filter(perm, ctype=ctype)
         if self.is_generic():
             filters &= Q(object_pk=str(obj.pk))
         else:


### PR DESCRIPTION
Since there were various point in which it was built a filter based on permission or in which it was required to check if the provided param was or not a permission, I just added a couple of utility methods to do those tasks.

Also I have fixed the type hints for `perm` param which were inaccurate because the code was expecting either `str` OR `Permission`.