### PR TITLE
documentation is refactored, ai rules are added

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
     - main
-    - next
   pull_request:
 
 env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,265 @@
+# Contributing to `django-guardian`
+
+Thank you for contributing to `django-guardian`.
+
+This project sits in the authorization and object-permission layer of Django applications, so correctness, backwards compatibility, and security matter as much as feature delivery. This document is the canonical contributor guide for the repository. Supporting docs under `docs/develop/` may explain individual tools in more detail, but maintainers review contributions against the standards in this file.
+
+## Before you start work
+
+### File an issue first
+
+For bug reports, feature requests, behavioral changes, or larger refactors, start by opening an issue in the repository:
+
+- <https://github.com/django-guardian/django-guardian/issues>
+
+This helps confirm that the proposal fits the project roadmap before significant implementation work begins. PRs that arrive without prior context may be closed if they are out of scope, too risky, or difficult to support long-term.
+
+### Do not report vulnerabilities publicly
+
+If you suspect a security issue, do **not** open a public issue or PR.
+
+Follow the process in `SECURITY.md` and use GitHub's private vulnerability reporting flow instead:
+
+- <https://github.com/django-guardian/django-guardian/security>
+
+## Branching and pull requests
+
+`django-guardian` uses two important long-lived branches:
+
+- `main`: latest stable release branch
+- `next`: integration branch for upcoming release candidates and unreleased work
+
+### Which branch should my PR target?
+
+Unless a maintainer explicitly asks otherwise, open pull requests against `next`.
+
+`main` should stay production-ready. New features and normal fixes should land in `next` first and then roll into the next release. If an urgent hotfix is needed for `main`, coordinate with the maintainers before opening the PR.
+
+### Recommended workflow
+
+1. Fork the repository.
+2. Clone your fork locally.
+3. Create a focused branch from `next`.
+4. Make the change with tests and documentation updates where relevant.
+5. Run the local checks listed below.
+6. Push your branch and open a PR against `next`.
+
+## Development environment
+
+The repository uses `uv` for dependency management and command execution.
+
+### Initial setup
+
+1. Install `uv`:
+   - <https://docs.astral.sh/uv/getting-started/installation/>
+2. Clone your fork of the repository.
+3. Sync the development environment:
+
+```bash
+uv sync --group dev
+```
+
+This creates and manages a local virtual environment and installs the package together with the development dependencies declared in `pyproject.toml`.
+
+If you want the broader dependency set used by CI for optional database backends, sync the `ci` group instead:
+
+```bash
+uv sync --group ci
+```
+
+## Local quality checks
+
+Run these before opening or updating a PR.
+
+### Run the main test suite
+
+```bash
+uv run pytest --cov=guardian --cov-report=xml --cov-report=term
+```
+
+Makefile alias:
+
+```bash
+make test
+```
+
+### Run the full tox matrix
+
+Use `tox` when you want parity with the supported Python/Django matrix, type-checking envs, docs build envs, and example project checks defined in `tox.ini`.
+
+```bash
+uv run tox run
+```
+
+To run a single environment:
+
+```bash
+uv run tox run -e core-py313-django51
+uv run tox run -e type-py313
+uv run tox run -e docs-py313-django51
+```
+
+Makefile alias for the full matrix:
+
+```bash
+make test-all
+```
+
+### Lint and type-check
+
+```bash
+uv run ruff check .
+uv run mypy ./guardian
+```
+
+Makefile alias:
+
+```bash
+make lint
+```
+
+### Auto-format before committing
+
+```bash
+uv run ruff check --fix .
+uv run ruff format .
+```
+
+Makefile alias:
+
+```bash
+make format
+```
+
+### Build the documentation
+
+```bash
+uv run mkdocs build
+```
+
+To preview docs locally:
+
+```bash
+uv run mkdocs serve
+```
+
+Makefile aliases:
+
+```bash
+make docs
+make docs-serve
+```
+
+### Migration sanity check
+
+If your change touches models, permissions models, or generated schema state, make sure migrations are in sync:
+
+```bash
+uv run python manage.py makemigrations --check --dry-run
+```
+
+The tox test environments perform this check automatically for the Django envs.
+
+## Code and review standards
+
+### Tests are required for behavior changes
+
+If you change behavior, fix a bug, optimize performance-sensitive code, or refactor permission logic, add or update tests that prove the change.
+
+`django-guardian` is security-sensitive and tightly integrated with Django's permission framework. A change that "looks right" is not enough; it must be demonstrated through tests.
+
+### Keep changes focused
+
+- Avoid drive-by refactors unrelated to the issue.
+- Preserve public APIs unless the change has been discussed first.
+- Call out any compatibility, migration, or performance impact in the PR description.
+- Update docs for user-visible behavior changes.
+
+### Follow repository tooling
+
+Current repository standards are defined primarily by:
+
+- `pyproject.toml` for dependencies, `ruff`, `mypy`, and `pytest` configuration
+- `tox.ini` for the supported test environments
+- `Makefile` for convenience commands
+
+If a doc page disagrees with those files, treat the configuration files as the source of truth.
+
+### Add yourself to project metadata
+
+If you would like to be credited as a contributor, add your name to the end of the `authors` list in `pyproject.toml`, preserving the existing ordering convention.
+
+## Pull request checklist
+
+Before requesting review, make sure your PR:
+
+- targets `next` unless a maintainer asked for `main`
+- links the relevant issue or clearly explains the context
+- includes tests for code changes
+- passes formatting, linting, typing, and relevant test commands locally
+- updates documentation when behavior or public APIs changed
+- explains any security, performance, or compatibility implications
+
+## Policy on AI and LLM usage in contributions
+
+We recognize that Artificial Intelligence (AI) and Large Language Models (LLMs) like GitHub Copilot, ChatGPT, Claude, and Gemini can accelerate development, assist in debugging, and help draft documentation.
+
+However, to maintain the standards, security, and integrity of `django-guardian`, we strictly prohibit **vibe-coding**: blindly generating and pasting code without understanding how it works.
+
+If you use AI tools to assist in your contribution, you must follow the rules below.
+
+### 1. Absolute developer ownership
+
+You are the sole author and owner of the code you submit. **"The AI generated it" is never a valid excuse** for bugs, security vulnerabilities, licensing problems, or architectural flaws.
+
+By submitting a PR, you are asserting that you understand every line of the change, how it integrates with the codebase, and what edge cases it introduces.
+
+### 2. Zero tolerance for vibe-coding and contribution spam
+
+We expect deliberate, context-aware engineering.
+
+- Do not submit raw, unedited LLM output.
+- Do not generate PRs just to increase contribution counts.
+- Automated or heavily AI-generated PRs that lack human review, project context, or adherence to this repository's standards may be closed without review.
+
+### 3. Verify every API, query, and compatibility claim
+
+LLMs frequently hallucinate APIs, invent nonexistent libraries, and suggest outdated or deprecated patterns.
+
+You must manually verify that AI-assisted changes do not introduce:
+
+- fake Django or Python APIs
+- deprecated Django behavior that will break in supported versions
+- incorrect query patterns that create N+1 issues or permission leakage
+- inaccurate typing, migration, or configuration changes
+
+### 4. Mandatory testing and verification
+
+AI output is probabilistic, not authoritative. Any AI-assisted logic change, refactor, or optimization must be covered by robust tests and verified locally with the repository tooling.
+
+For non-trivial changes, that typically means running some combination of:
+
+- `uv run pytest --cov=guardian --cov-report=xml --cov-report=term`
+- `uv run tox run`
+- `uv run ruff check .`
+- `uv run mypy ./guardian`
+
+If the change affects docs, examples, or release flow, verify those too.
+
+### 5. Security and intellectual property
+
+LLMs are trained on large volumes of public code and can sometimes reproduce copyrighted snippets or reintroduce known vulnerabilities.
+
+It is your responsibility to ensure that your contribution:
+
+- does not violate project licensing expectations
+- follows Django security best practices
+- does not expose private data, unsafe serialization, SQL injection risk, or permission bypasses
+
+### 6. Transparency and disclosure
+
+If a significant portion of your implementation, architecture, or refactoring was drafted with AI assistance, disclose that in the PR description.
+
+Example:
+
+> *Note: I used [Tool Name] to help draft the initial logic for this change. I manually reviewed and adapted the result to fit `django-guardian`, and I added tests and local verification for the final implementation.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,25 +24,28 @@ Follow the process in `SECURITY.md` and use GitHub's private vulnerability repor
 
 ## Branching and pull requests
 
-`django-guardian` uses two important long-lived branches:
+`django-guardian` uses a single long-lived branch:
 
-- `main`: latest stable release branch
-- `next`: integration branch for upcoming release candidates and unreleased work
+- `main`: active development and release branch
 
 ### Which branch should my PR target?
 
-Unless a maintainer explicitly asks otherwise, open pull requests against `next`.
+Unless a maintainer explicitly asks otherwise, open pull requests against `main`.
 
-`main` should stay production-ready. New features and normal fixes should land in `next` first and then roll into the next release. If an urgent hotfix is needed for `main`, coordinate with the maintainers before opening the PR.
+All regular fixes and features are developed and merged on `main`.
+
+### How are releases created?
+
+When a new version is ready, maintainers cut the release from the GitHub web interface and create the corresponding version tag there.
 
 ### Recommended workflow
 
 1. Fork the repository.
 2. Clone your fork locally.
-3. Create a focused branch from `next`.
+3. Create a focused branch from `main`.
 4. Make the change with tests and documentation updates where relevant.
 5. Run the local checks listed below.
-6. Push your branch and open a PR against `next`.
+6. Push your branch and open a PR against `main`.
 
 ## Development environment
 
@@ -193,7 +196,6 @@ If you would like to be credited as a contributor, add your name to the end of t
 
 Before requesting review, make sure your PR:
 
-- targets `next` unless a maintainer asked for `main`
 - links the relevant issue or clearly explains the context
 - includes tests for code changes
 - passes formatting, linting, typing, and relevant test commands locally

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,19 @@
-.PHONY: help build pytest test clean install dev-install lint format docs
+.PHONY: help build pytest test test-all clean install dev-install lint format docs docs-serve check
 
 help:
 	@echo "Available commands:"
 	@echo "  build        - Build the package"
 	@echo "  pytest       - Run tests with pytest"
 	@echo "  test         - Alias for pytest"
+	@echo "  test-all     - Run the full tox matrix"
 	@echo "  clean        - Clean build artifacts"
-	@echo "  install      - Install the package"
-	@echo "  dev-install  - Install package in development mode with dev dependencies"
+	@echo "  install      - Sync project dependencies"
+	@echo "  dev-install  - Sync project with development dependencies"
 	@echo "  lint         - Run linting checks"
-	@echo "  format       - Format code"
+	@echo "  format       - Apply Ruff fixes and format code"
 	@echo "  docs         - Build documentation"
+	@echo "  docs-serve   - Serve documentation locally"
+	@echo "  check        - Run lint, tests, and docs build"
 
 # Build the package
 build:
@@ -18,36 +21,57 @@ build:
 
 # Run tests with pytest
 pytest:
-	pytest --cov=guardian --cov-report=xml --cov-report=term
+	uv run pytest --cov=guardian --cov-report=xml --cov-report=term
 
 # Alias for pytest
 test: pytest
+
+# Run the full tox matrix
+test-all:
+	uv run tox run
 
 # Clean build artifacts
 clean:
 	rm -rf build/
 	rm -rf dist/
 	rm -rf *.egg-info/
+	rm -rf .coverage
+	rm -rf .mypy_cache/
+	rm -rf .pytest_cache/
+	rm -rf .ruff_cache/
+	rm -rf .tox/
+	rm -rf htmlcov/
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 
-# Install the package
+# Sync the default project environment
 install:
-	uv pip install .
+	uv sync
 
-# Install in development mode with dev dependencies
+# Sync the development environment
 dev-install:
-	uv pip install -e . --group dev
+	uv sync --group dev
 
 # Run linting checks
 lint:
-	ruff check .
-	mypy ./guardian
+	uv run ruff check .
+	uv run mypy ./guardian
 
-# Format code
+# Apply auto-fixes and format code
 format:
-	ruff format .
+	uv run ruff check --fix .
+	uv run ruff format .
 
 # Build documentation
 docs:
-	mkdocs build
+	uv run mkdocs build
+
+# Serve documentation locally
+docs-serve:
+	uv run mkdocs serve
+
+# Run the most common local checks
+check:
+	$(MAKE) lint
+	$(MAKE) test
+	$(MAKE) docs

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Online documentation is available at [https://django-guardian.readthedocs.io/](h
 
 **See real-world usage**: Check out [Who Uses Guardian](https://django-guardian.readthedocs.io/en/stable/who-uses-guardian/) to see how thousands of projects worldwide use django-guardian in production.
 
+## Contributing
+
+Please read [`CONTRIBUTING.md`](./CONTRIBUTING.md) before opening a pull request. It documents the repository's issue-first workflow, branch targeting rules, local `uv` setup, required test and lint commands, documentation expectations, and AI/LLM contribution policy.
+
+If you need to report a security issue, do **not** open a public issue. Follow [`SECURITY.md`](./SECURITY.md) and use the repository's [private vulnerability reporting flow](https://github.com/django-guardian/django-guardian/security).
+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Online documentation is available at [https://django-guardian.readthedocs.io/](h
 
 ## Contributing
 
-Please read [`CONTRIBUTING.md`](./CONTRIBUTING.md) before opening a pull request. It documents the repository's issue-first workflow, branch targeting rules, local `uv` setup, required test and lint commands, documentation expectations, and AI/LLM contribution policy.
+Please read [`CONTRIBUTING.md`](https://github.com/django-guardian/django-guardian/blob/main/CONTRIBUTING.md) before opening a pull request. It documents the repository's issue-first workflow, branch targeting rules, local `uv` setup, required test and lint commands, documentation expectations, and AI/LLM contribution policy.
 
-If you need to report a security issue, do **not** open a public issue. Follow [`SECURITY.md`](./SECURITY.md) and use the repository's [private vulnerability reporting flow](https://github.com/django-guardian/django-guardian/security).
+If you need to report a security issue, do **not** open a public issue. Follow [`SECURITY.md`](https://github.com/django-guardian/django-guardian/blob/main/SECURITY.md) and use the repository's [private vulnerability reporting flow](https://github.com/django-guardian/django-guardian/security).
 
 
 ## Installation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,14 @@
 
 ## Supported Versions
 
-Due to limited resources, only the latest version of django-guardian will be supported with security updates (ie we won't do patch updates to prior minor versions).
+Due to limited resources, only the latest version of `django-guardian` is supported with security updates. We do not generally issue security fixes for older minor release lines.
 
 ## Reporting a Vulnerability
 
 Please do NOT describe issues which may indicate vulnerabilities or demonstrate possible exploits in an issue, which will be public.
 
-Instead, please prepare a demo and description of the explout and visit the [security tab on the repository](https://github.com/django-guardian/django-guardian/security) to report an issue confidentially.
+Instead, prepare a clear description and, if possible, a minimal reproduction or demo of the exploit, then use the repository's [private vulnerability reporting flow](https://github.com/django-guardian/django-guardian/security) to report it confidentially.
 
 ## How we manage vulnerabilities
 
-The maintainers will review the vulnerability, and use GitHub's security settings to publish an advisory whilst issuing a release to fix the problem.
+The maintainers will review the report, coordinate a fix, and use GitHub's security tooling to publish an advisory when appropriate.

--- a/docs/develop/makefile.md
+++ b/docs/develop/makefile.md
@@ -5,22 +5,23 @@ description: How to use the Makefile commands for building, testing, and develop
 
 # Makefile Commands
 
-Django Guardian includes a comprehensive Makefile that provides convenient commands for common development tasks. The Makefile uses `uv` as the package manager and includes commands for building, testing, linting, and more.
+Django Guardian includes a Makefile that wraps the repository's standard `uv`-based workflow. The targets are convenience aliases for the commands documented in `CONTRIBUTING.md`, `pyproject.toml`, and `tox.ini`.
 
 ## Prerequisites
 
 Before using the Makefile commands, ensure you have:
 
 - `uv` package manager installed
-- A virtual environment activated (if using one)
-- Development dependencies installed (`uv pip install -e . --group dev`)
+- Synced the development environment (`uv sync --group dev`)
+
+Because the Makefile uses `uv run`, you do **not** need to activate a virtual environment manually.
 
 ## Available Commands
 
 To see all available commands with descriptions:
 
 ```shell
-$ make help
+make help
 ```
 
 This will display:
@@ -30,12 +31,15 @@ Available commands:
   build        - Build the package
   pytest       - Run tests with pytest
   test         - Alias for pytest
+  test-all     - Run the full tox matrix
   clean        - Clean build artifacts
-  install      - Install the package
-  dev-install  - Install package in development mode with dev dependencies
+  install      - Sync project dependencies
+  dev-install  - Sync project with development dependencies
   lint         - Run linting checks
-  format       - Format code
+  format       - Apply Ruff fixes and format code
   docs         - Build documentation
+  docs-serve   - Serve documentation locally
+  check        - Run lint, tests, and docs build
 ```
 
 ## Core Commands
@@ -45,7 +49,7 @@ Available commands:
 To build the django-guardian package (creates both source distribution and wheel):
 
 ```shell
-$ make build
+make build
 ```
 
 This command uses `uv build` to create distribution files in the `dist/` directory.
@@ -55,16 +59,26 @@ This command uses `uv build` to create distribution files in the `dist/` directo
 To run the test suite with pytest and coverage reporting:
 
 ```shell
-$ make pytest
+make pytest
 ```
 
 Or use the alias:
 
 ```shell
-$ make test
+make test
 ```
 
 This command runs pytest with coverage for the guardian module and generates both XML and terminal coverage reports.
+
+### Running the Full Matrix
+
+To run the full tox matrix defined in `tox.ini`:
+
+```shell
+make test-all
+```
+
+This is equivalent to `uv run tox run`.
 
 ## Development Commands
 
@@ -73,13 +87,25 @@ This command runs pytest with coverage for the guardian module and generates bot
 To install the package in development mode with all development dependencies:
 
 ```shell
-$ make dev-install
+make dev-install
+```
+
+This target runs:
+
+```shell
+uv sync --group dev
 ```
 
 For a regular installation:
 
 ```shell
-$ make install
+make install
+```
+
+This target runs:
+
+```shell
+uv sync
 ```
 
 ### Code Quality
@@ -87,13 +113,13 @@ $ make install
 To run linting checks (ruff and mypy):
 
 ```shell
-$ make lint
+make lint
 ```
 
-To format code using ruff:
+To apply Ruff auto-fixes and then format the code:
 
 ```shell
-$ make format
+make format
 ```
 
 ### Documentation
@@ -101,7 +127,19 @@ $ make format
 To build the documentation using mkdocs:
 
 ```shell
-$ make docs
+make docs
+```
+
+To preview the documentation locally:
+
+```shell
+make docs-serve
+```
+
+To run the most common local verification steps in sequence:
+
+```shell
+make check
 ```
 
 ### Cleaning Build Artifacts
@@ -109,13 +147,19 @@ $ make docs
 To clean up build artifacts, distribution files, and cache:
 
 ```shell
-$ make clean
+make clean
 ```
 
 This removes:
 - `build/` directory
 - `dist/` directory
 - `*.egg-info/` directories
+- `.coverage`
+- `.mypy_cache/`
+- `.pytest_cache/`
+- `.ruff_cache/`
+- `.tox/`
+- `htmlcov/`
 - `__pycache__` directories
 - `.pyc` files
 
@@ -126,47 +170,46 @@ Here are some common development workflows using the Makefile:
 ### Setting up for development:
 
 ```shell
-$ make dev-install
-$ make test
+make dev-install
+make test
 ```
 
 ### Before committing changes:
 
 ```shell
-$ make format
-$ make lint
-$ make test
+make format
+make lint
+make test
 ```
 
 ### Creating a release:
 
 ```shell
-$ make clean
-$ make build
+make clean
+make build
 ```
 
 ### Full development cycle:
 
 ```shell
 # Setup
-$ make dev-install
+make dev-install
 
 # Development
-$ make format
-$ make lint
-$ make test
+make format
+make lint
+make test
 
 # Build and documentation
-$ make build
-$ make docs
+make build
+make docs
 
 # Cleanup
-$ make clean
+make clean
 ```
 
 ## Notes
 
-- All commands use `uv` as the package manager, which is faster and more reliable than pip
-- The Makefile is designed to work with the existing project structure and dependencies
-- Commands are optimized for the django-guardian project's specific needs
-- Coverage reports are generated automatically when running tests
+- All executable targets use the repository's managed `uv` environment.
+- `Makefile` is a convenience layer; `CONTRIBUTING.md`, `pyproject.toml`, and `tox.ini` remain the canonical sources of truth.
+- Coverage reports are generated automatically when running `make pytest` or `make test`.

--- a/docs/develop/overview.md
+++ b/docs/develop/overview.md
@@ -1,3 +1,4 @@
+---
 title: Contributing
 description: Where to find the canonical contributor guide and the supporting development docs.
 ---

--- a/docs/develop/overview.md
+++ b/docs/develop/overview.md
@@ -1,143 +1,27 @@
----
 title: Contributing
-description: Frequently Asked Questions about how to contribute to the django-guardian.
+description: Where to find the canonical contributor guide and the supporting development docs.
 ---
 
-# Contributing FAQ
+# Contributing
 
-Django Guardian is an open-source project, and we welcome contributions from the community.
-However, since Guardian is a security-focused project, there are additional guidelines and rules
-for contributors that may be a little different from other open-source projects.
+The canonical contributor guide for this repository lives in the root [`CONTRIBUTING.md`](https://github.com/django-guardian/django-guardian/blob/main/CONTRIBUTING.md).
 
-## Why is `next` the default branch?
+That file is the source of truth for:
 
-The `main` branch is always in a production-ready state. The tip of
-`main` contains the latest full (ie non-candidate) release. New PRs
-should be made into the `next` branch to be first release as a _candidate_
-and batched with other PRs into the next versioned release.
+- issue-first contribution workflow
+- `next` vs `main` pull request targeting
+- local setup with `uv`
+- required test, lint, type-check, and docs commands
+- review expectations and AI/LLM contribution policy
 
-The `next` branch, can potentially break. As a user, you should NEVER use
-non-main branches in production (if you're desperate
-for a feature or fix not yet released, either use a SHA to install at a
-specific commit, or install a release candidate tag).
+This page intentionally stays lightweight so that contribution guidance is maintained in one place and does not drift.
 
-## How do I file a ticket?
+## Supporting development docs
 
-Have a bug, feature request, or question?
+Use the pages in this section for tool-specific details:
 
-Create a ticket in [The repo issue tracker](https://github.com/django-guardian/django-guardian/issues)
+- [Testing](testing.md)
+- [Makefile Commands](makefile.md)
+- [Release Process](release.md)
 
-If you would like to contribute,
-it's important to make sure that your ideas are in line with the project goals before you start working.
-Describe your bug, feature request, or question with enough details and context to allow the team to understand your request.
-
-## How do I get involved?
-
-You are cordially invited to contribute to the Django Guardian project!
-Django Guardian welcomes all types of contributions, from bug reports to documentation.
-
-Start by [filing a ticket](#how-do-i-file-a-ticket) in the issue tracker.
-
-Then, [fork the project on github](https://github.com/django-guardian/django-guardian/fork), create a separate branch, work on it, push changes to your fork and create a pull request.
-
-Here is a quick how to:
-
-1.  Fork a project [here](https://github.com/django-guardian/django-guardian/fork)
-2.  Checkout project to your local machine
-
-    ```shell
-    $ git clone git@github.com:YOUR_NAME/django-guardian.git
-    ```
-
-3.  Create a new branch with name describing change you are going to work on
-
-    ```shell
-    $ git checkout -b support-for-custom-model
-    ```
-
-4.  Perform changes at newly created branch. Remember to include tests (if this
-    is code related change) and run test suite. See `running tests documentation
-<testing>`. Also, remember to add yourself to the bottom of the `authors` entry in `pyproject.toml`.
-
-5.  (Optional) Squash commits. If you have multiple commits and it doesn't make
-    much sense to have them separated (and it usually makes little sense),
-    please consider merging all changes into single commit (if you're not sure about this, the maintainers will likely squash commits on merging, so don't worry too much).
-
-6.  Make sure your PR is up to date with latest changes (it should be ahead of the
-    "tip" of the `next` branch that you're mergin into). Please see
-    [GitHub's help on interactive rebasing](https://help.github.com/articles/interactive-rebase) if you need help with
-    that.
-
-7.  Publish changes
-
-    ```shell
-    $ git push origin YOUR_BRANCH_NAME
-    ```
-
-8.  Create a [Pull Request](https://help.github.com/articles/creating-a-pull-request).
-    Usually it's as simple as opening up https://github.com/YOUR_NAME/django-guardian
-    and clicking on review button for newly created branch. There you can make
-    final review of your changes and if everything seems fine, create a Pull
-    Request.
-
-## Installing dev dependencies and running tests
-
-1. Install the `uv` package manager by [following the instructions here](https://docs.astral.sh/uv/getting-started/installation/).
-
-2. Install tox tool and its plugins into your local environment:
-    ```
-    uv tool install --python-preference only-managed --python 3.13 tox --with . --with tox-uv
-    ```
-
-3. First check all the test environments will install for you (without actually running the tests):
-    ```
-    tox run -n
-    ```
-
-4. Run all the tests:
-    ```
-    tox run
-    ```
-
-Under the hood, the tests use `pytest` so of course, you can set up your IDE to use pytest directly alternatively.
-
-
-## Why was my issue/pull request closed?
-
-We usually put an explanation when we close an issue or PR. Common reasons:
-
-- no reply for over a month after our last comment or review
-- no tests for the changes, or failing tests
-- there are performance implications of the changes
-- PRs made out of the blue without filing an issue first
-- breaking changes we don't want to introduce
-- out-of-scope features
-- features or approaches that are difficult to support going forwards
-
-## How do I update the documentation?
-
-Documentation is stored in `docs` folder.
-To update the documentation, you can edit the Markdown files directly.
-If you need to add new pages, or view the documentation locally, you can use the following steps:
-
-1. Install the required packages:
-
-   ```shell
-   pip install -r docs/requirements.txt
-   ```
-
-2. Run the documentation server:
-
-   ```shell
-   mkdocs serve
-   ```
-
-The CLI will provide you a link to view the documentation running locally (usually `http://127.0.0.1:8000`).
-
-See the [ReadTheDocs' documentation on using MkDocs](https://docs.readthedocs.com/platform/stable/intro/mkdocs.html)
-for more information.
-
-## How do I make a release?
-
-See the dedicated [Release Process](release.md) page for full instructions on creating
-standard releases, release candidates, and hotfix releases.
+If any supporting page disagrees with `CONTRIBUTING.md`, `pyproject.toml`, `tox.ini`, or `Makefile`, treat those repository files as authoritative.

--- a/docs/develop/overview.md
+++ b/docs/develop/overview.md
@@ -10,7 +10,7 @@ The canonical contributor guide for this repository lives in the root [`CONTRIBU
 That file is the source of truth for:
 
 - issue-first contribution workflow
-- `next` vs `main` pull request targeting
+- `main` pull request targeting
 - local setup with `uv`
 - required test, lint, type-check, and docs commands
 - review expectations and AI/LLM contribution policy

--- a/docs/develop/release.md
+++ b/docs/develop/release.md
@@ -21,9 +21,9 @@ Before starting a release, make sure you have:
 - A local clone of the repository, up to date with the remote
 - The development environment synced locally:
 
-```shell
-uv sync --group dev
-```
+    ```shell
+    uv sync --group dev
+    ```
 
 ## Step 1: Run Tests Locally
 

--- a/docs/develop/release.md
+++ b/docs/develop/release.md
@@ -19,6 +19,11 @@ Before starting a release, make sure you have:
 - Write access to the [django-guardian repository](https://github.com/django-guardian/django-guardian)
 - Permission to trigger GitHub Actions workflows
 - A local clone of the repository, up to date with the remote
+- The development environment synced locally:
+
+```shell
+uv sync --group dev
+```
 
 ## Step 1: Run Tests Locally
 
@@ -26,13 +31,13 @@ Before any release, all tests **must** pass. For extra safety, run the test suit
 pushing any version bump:
 
 ```shell
-tox run
+uv run tox run
 ```
 
 Or if you want to run a quick check with a single Python/Django combination:
 
 ```shell
-pytest
+uv run pytest --cov=guardian --cov-report=xml --cov-report=term
 ```
 
 !!! tip

--- a/docs/develop/release.md
+++ b/docs/develop/release.md
@@ -92,7 +92,7 @@ Type the **branch name** or **commit SHA** of the code you want to release:
 | Scenario               | Value to enter                                      |
 |------------------------|-----------------------------------------------------|
 | Standard release       | `main`                                              |
-| Release candidate (RC) | The feature/RC branch name (e.g. `next`, `rc/3.4`)  |
+| Release candidate (RC) | `main` (or a specific commit SHA from `main`)        |
 | Hotfix release         | The hotfix branch name or a specific commit SHA      |
 
 ### 3.3 Tag
@@ -129,12 +129,12 @@ A standard release ships stable, production-ready code from the `main` branch.
 
 A release candidate allows testing a new version before making it generally available.
 
-1. Create or use an existing branch (e.g. `next` or `rc/3.4`).
+1. Keep changes on `main` and prepare the RC version there.
 2. Update `pyproject.toml` → `version` with an `rc` suffix (e.g. `3.4.0rc1`).
-3. Commit and push to the RC branch.
+3. Commit and push to `main`.
 4. Trigger the workflow:
     - **Workflow branch (dropdown):** the branch containing the workflow file you want to use
-    - **Branch to release:** the RC branch name (e.g. `next`)
+    - **Branch to release:** `main` (or a specific commit SHA from `main`)
     - **Tag:** the RC version (e.g. `3.4.0rc1`)
 
 !!! info
@@ -149,7 +149,7 @@ For urgent fixes that need to go out outside the normal release cycle:
 2. Apply the fix and update `pyproject.toml` → `version` (increment the patch version).
 3. Run tests locally and push.
 4. Trigger the workflow with the hotfix branch name or commit SHA.
-5. After a successful release, merge the hotfix back into `main` and `next`.
+5. After a successful release, merge the hotfix back into `main`.
 
 ---
 

--- a/docs/develop/testing.md
+++ b/docs/develop/testing.md
@@ -19,7 +19,7 @@ This page focuses specifically on running the test and verification tooling used
     Instead, follow the process in the project's [security policy](https://github.com/django-guardian/django-guardian/blob/main/SECURITY.md)
     and use the repository's [private vulnerability reporting flow](https://github.com/django-guardian/django-guardian/security).
 
-If you find a non-security related bug in this application,
+If you find a non-security related bug in this project,
 please take a minute and file a ticket in our
 [issue tracker](https://github.com/django-guardian/django-guardian/issues).
 

--- a/docs/develop/testing.md
+++ b/docs/develop/testing.md
@@ -5,47 +5,70 @@ description: How to run the test harness, generate coverage reports, and other c
 
 # Testing
 
-## Introduction
+The full contributor workflow, branch policy, PR expectations, and AI/LLM policy are documented in the root [`CONTRIBUTING.md`](https://github.com/django-guardian/django-guardian/blob/main/CONTRIBUTING.md).
 
-According to [OWASP](http://www.owasp.org/),
-[broken authentication](http://www.owasp.org/index.php/Top_10_2010-A3) is one of
-the most common security issues exposed in web applications.
+This page focuses specifically on running the test and verification tooling used by this repository.
 
-`django-guardian` extends the capabilities of Django's authorization facilities,
-as such it has to be tested thoroughly.
-It is extremely important that Guardian provides the simplest `api` as possible,
-with a have a high test scenario coverage.
+`django-guardian` extends Django's authorization framework, so regressions can have security implications. Changes in permission logic should be treated as security-sensitive and verified thoroughly.
 
 !!! danger "Security Risks"
     If you spot a *security risk* or a bug that might affect security of systems that use `django-guardian`,
 
     **DO NOT create a public issue**.
 
-    Instead, contact the Guardian maintainer team directly.
-    You can find contact information in the [SECURITY.md file](https://github.com/django-guardian/django-guardian/blob/devel/.github/SECURITY.md)
+    Instead, follow the process in the project's [security policy](https://github.com/django-guardian/django-guardian/blob/main/SECURITY.md)
+    and use the repository's [private vulnerability reporting flow](https://github.com/django-guardian/django-guardian/security).
 
 If you find a non-security related bug in this application,
 please take a minute and file a ticket in our
-[issue-tracker](http://github.com/django-guardian/django-guardian).
+[issue tracker](https://github.com/django-guardian/django-guardian/issues).
+
+## Local setup
+
+Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/) and sync the development environment:
+
+```shell
+uv sync --group dev
+```
+
+If you need the optional database dependencies used by the broader CI matrix, sync the `ci` dependency group instead:
+
+```shell
+uv sync --group ci
+```
 
 ## Running tests
 
-Tests are run by Django's building test runner. To call it simply run:
+The fastest local test command is the main `pytest` suite with coverage:
 
 ```shell
-$ python setup.py test
+uv run pytest --cov=guardian --cov-report=xml --cov-report=term
 ```
 
-or inside a project with `guardian` set at `INSTALLED_APPS`:
+Makefile alias:
 
 ```shell
-$ python manage.py test guardian
+make test
 ```
 
-or using the bundled `testapp` project:
+If you want full matrix parity with the environments defined in `tox.ini`, run:
 
 ```shell
-$ python manage.py test
+uv run tox run
+```
+
+To run a specific environment only:
+
+```shell
+uv run tox run -e core-py313-django51
+uv run tox run -e type-py313
+uv run tox run -e docs-py313-django51
+```
+
+Makefile alias for the full matrix:
+
+```shell
+make test-all
 ```
 
 ## Coverage support
@@ -59,69 +82,59 @@ specification of almost all applications requires some unique scenarios
 to be tested). On the other hand it definitely helps to track missing
 parts.
 
-To run tests with [coverage](http://nedbatchelder.com/code/coverage/)
-support and show the report after we have provided simple bash script
-which can by called by running:
+The repository's standard coverage command is already included in the default pytest invocation:
 
 ```shell
-$ ./run_test_and_report.sh
+uv run pytest --cov=guardian --cov-report=xml --cov-report=term
 ```
 
-Result should be somehow similar to following:
+This produces:
 
-```shell
-(...)
-................................................
-----------------------------------------------------------------------
-Ran 48 tests in 2.516s
-
-OK
-Destroying test database 'default'...
-Name                                  Stmts   Exec  Cover   Missing
--------------------------------------------------------------------
-guardian/__init__                         4      4   100%
-guardian/backends                        20     20   100%
-guardian/conf/__init__                    1      1   100%
-guardian/core                            29     29   100%
-guardian/exceptions                       8      8   100%
-guardian/management/__init__             10     10   100%
-guardian/managers                        40     40   100%
-guardian/models                          36     36   100%
-guardian/shortcuts                       30     30   100%
-guardian/templatetags/__init__            1      1   100%
-guardian/templatetags/guardian_tags      39     39   100%
-guardian/utils                           13     13   100%
--------------------------------------------------------------------
-TOTAL                                   231    231   100%
-```
+- terminal coverage output for quick review
+- `coverage.xml` for CI/reporting integrations
 
 ## Tox
 
-
-!!! abstract "Added in version 1.0.4"
-
-We also started using [tox](http://pypi.python.org/pypi/tox) to ensure
-`django-guardian`'s tests would pass on all supported Python and Django
-versions (see `supported-versions`).
+`tox` is the canonical way to exercise the supported Python/Django combinations,
+type-checking environment, docs build environment, and example project checks.
 
 ```shell
-pip install tox
+uv run tox run
 ```
 
-and run it within `django-guardian` checkout directory:
+Useful examples:
 
 ```shell
-tox
+uv run tox run -e core-py314-django52
+uv run tox run -e core-py312-djangomain
+uv run tox run -e example-py313-django51
+uv run tox run -e examplegroup-py313-django51
 ```
 
-First time contributors should take some time (it needs to create separate virtual
-environments and pull dependencies) but would ensure everything is fine.
+If you change models or permission schema state, also run the migration sanity check used by the Django tox environments:
+
+```shell
+uv run python manage.py makemigrations --check --dry-run
+```
+
+## Linting, typing, and docs verification
+
+Repository changes should usually be verified with more than just tests.
+
+```shell
+uv run ruff check .
+uv run mypy ./guardian
+uv run mkdocs build
+```
+
+Makefile aliases:
+
+```shell
+make lint
+make docs
+```
 
 ## GitHub Actions
 
-!!! abstract "Added in version 2.4.0"
-
-[![image](https://github.com/django-guardian/django-guardian/workflows/Tests/badge.svg?branch=devel)](https://github.com/django-guardian/django-guardian/actions/workflows/tests.yml)
-
 We have support for [GitHub Actions](https://github.com/django-guardian/django-guardian/actions)
-to make it easy to follow if test fails with new commits.
+to run the same general checks in CI. Local verification with `pytest`, `tox`, `ruff`, `mypy`, and `mkdocs` helps catch problems before you open or update a pull request.

--- a/docs/who-uses-guardian.md
+++ b/docs/who-uses-guardian.md
@@ -108,4 +108,4 @@ Feel free to reach out through our community channels.
 
 ---
 
-*Want to contribute to this page? We welcome additions of projects using django-guardian. Please see our [contribution guidelines](develop/overview.md) for more information.*
+*Want to contribute to this page? We welcome additions of projects using django-guardian. Please see our [contribution guidelines](https://github.com/django-guardian/django-guardian/blob/main/CONTRIBUTING.md) for more information.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ dependencies = [
 Homepage = "https://github.com/django-guardian/django-guardian"
 Documentation = "https://django-guardian.readthedocs.io/"
 Repository = "https://github.com/django-guardian/django-guardian"
-Issues = "https://github.com/me/spam/issues"
+Issues = "https://github.com/django-guardian/django-guardian/issues"
 Changelog = "https://github.com/django-guardian/django-guardian/releases"
 
 [dependency-groups]


### PR DESCRIPTION
https://github.com/django-guardian/django-guardian/issues/984

## What this PR changes

This PR cleans up and consolidates contributor/release documentation, and aligns local tooling guidance with the current repository workflow.

### Highlights

- Adds a new root-level `CONTRIBUTING.md` as the canonical contributor guide, including:
  - issue-first workflow
  - branch/PR targeting (`main`)
  - local `uv` setup and standard quality commands
  - AI/LLM contribution expectations and disclosure policy

- Refactors development docs to avoid drift and point to the canonical guide:
  - `docs/develop/overview.md` is now a lightweight index page
  - `docs/develop/testing.md` is updated to current `uv` + `pytest`/`tox` workflow
  - `docs/develop/makefile.md` is updated to match actual Makefile targets
  - `docs/develop/release.md` is updated for current release flow (including RC/hotfix guidance around `main`)

- Modernizes `Makefile` targets to use `uv run` consistently and adds convenience targets:
  - new: `test-all`, `docs-serve`, `check`
  - improved cleanup (`.coverage`, caches, `.tox`, `htmlcov`)
  - clarified `install`/`dev-install` to use `uv sync`

- Improves project metadata and docs links:
  - fixes `Issues` URL in `pyproject.toml`
  - adds contribution/security pointers in `README.md`
  - updates stale contribution link in `docs/who-uses-guardian.md`
  - clarifies wording in `SECURITY.md`

## Why

Several contributor-facing docs had become inconsistent with the current workflow (branch strategy, test commands, and setup instructions). This PR centralizes policy in one canonical place and updates supporting docs/tooling so contributors get one consistent path.

## Scope / Risk

- No runtime changes to `guardian` application code.
- This is a docs + developer workflow update (plus metadata/link fixes), with low behavioral risk for end users.

## Notes for reviewers

- Main focus is consistency between `CONTRIBUTING.md`, `Makefile`, and docs under `docs/develop/`.
- Please check wording/policy tone in the AI/LLM section to ensure it matches maintainer expectations.
