### PR TITLE
Remove a query in prefetch_perms() #813

### DIFF
--- a/guardian/core.py
+++ b/guardian/core.py
@@ -245,8 +245,8 @@ class ObjectPermissionChecker:
             perms = group_model.objects.filter(**group_filters).select_related("permission")
 
         # initialize entry in '_obj_perms_cache' for all prefetched objects
-        for obj in objects:
-            key = self.get_local_cache_key(obj)
+        # The ctype is assumed above to be homogenous, so leave `objects` unevaluated.
+        for key in ((ctype.id, pk) for pk in pks):
             if key not in self._obj_perms_cache:
                 self._obj_perms_cache[key] = []
 

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -6,7 +6,9 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.management import create_permissions
 from django.contrib.auth.models import AnonymousUser, Group, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 
 from guardian.conf import settings as guardian_settings
 from guardian.core import ObjectPermissionChecker
@@ -610,3 +612,13 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
             self.assertGreater(len(connection.queries), query_count)
         finally:
             settings.DEBUG = False
+
+    def test_prefetch_performance(self):
+        GroupObjectPermission.objects.assign_perm("delete_contenttype", self.group, self.ctype)
+    
+        checker = ObjectPermissionChecker(self.user)
+        with CaptureQueriesContext(connection) as queries:
+            checker.prefetch_perms(Group.objects.all())
+
+        group_selects = [q for q in queries if q["sql"].endswith('FROM "auth_group"')]
+        self.assertEqual(len(group_selects), 1)

--- a/guardian/testapp/tests/test_core.py
+++ b/guardian/testapp/tests/test_core.py
@@ -614,11 +614,11 @@ class ObjectPermissionCheckerTest(ObjectPermissionTestCase):
             settings.DEBUG = False
 
     def test_prefetch_performance(self):
-        GroupObjectPermission.objects.assign_perm("delete_contenttype", self.group, self.ctype)
-    
         checker = ObjectPermissionChecker(self.user)
         with CaptureQueriesContext(connection) as queries:
             checker.prefetch_perms(Group.objects.all())
 
-        group_selects = [q for q in queries if q["sql"].endswith('FROM "auth_group"')]
+        auth_group_from = "FROM %s" % connection.ops.quote_name("auth_group")
+        # Ignore other queries that JOIN this table.
+        group_selects = [q for q in queries if q["sql"].endswith(auth_group_from)]
         self.assertEqual(len(group_selects), 1)


### PR DESCRIPTION
Closes #813

Before, this test demonstrated that two queries were done to accomplish prefetching of permissions. One to the get the PK, and one to get the whole row.

Now, because this code already assumed that the `ctype` was homogenous, and because the `pk` was already run through `force_str()`, we can just generate the cache keys inline without evaluating `objects`. This saves one (potentially large) query.

Alternative to #983