### PR TITLE
Fix permission filtering for joined querysets

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -1006,4 +1006,3 @@ def filter_perms_queryset_by_objects(perms_queryset, objects):
         return perms_queryset.filter(**{"{}__in".format(field): objects})
     else:
         return perms_queryset
-

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -984,19 +984,26 @@ def filter_perms_queryset_by_objects(perms_queryset, objects):
                 if _casts_to_bigint(handle_pk_field):
                     # Keep object_pk untouched to avoid CAST(object_pk AS bigint)
                     # scans on large guardian tables. We only stringify model PKs.
-                    objects = objects.values(_pk=Cast("pk", output_field=CharField()))
+                    # Use annotate + values_list instead of values() to guarantee
+                    # exactly one column when the queryset has existing joins (#992).
+                    objects = objects.annotate(
+                        _pk=Cast("pk", output_field=CharField())
+                    ).values_list("_pk", flat=True)
                     field = "object_pk"
                 else:
-                    objects = objects.values(_pk=Cast(handle_pk_field("pk"), output_field=CharField()))
+                    objects = objects.annotate(
+                        _pk=Cast(handle_pk_field("pk"), output_field=CharField())
+                    ).values_list("_pk", flat=True)
                     # Apply the same transformation to the object_pk field for consistent comparison (#930)
                     perms_queryset = perms_queryset.annotate(
                         _transformed_object_pk=Cast(handle_pk_field(field), output_field=CharField())
                     )
                     field = "_transformed_object_pk"
             else:
-                objects = objects.values("pk")
+                objects = objects.values_list("pk", flat=True)
         else:
-            objects = objects.values("pk")
+            objects = objects.values_list("pk", flat=True)
         return perms_queryset.filter(**{"{}__in".format(field): objects})
     else:
         return perms_queryset
+

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -17,12 +17,13 @@ from guardian.exceptions import (
     NotUserNorGroup,
     WrongAppError,
 )
-from guardian.models import Group, Permission
+from guardian.models import Group, Permission, UserObjectPermission
 import guardian.shortcuts as guardian_shortcuts
 from guardian.shortcuts import (
     _get_ct_cached,
     assign,
     assign_perm,
+    filter_perms_queryset_by_objects,
     get_group_perms,
     get_groups_with_perms,
     get_objects_for_group,
@@ -1336,6 +1337,27 @@ class GetObjectsForUser(TestCase):
         self.assertEqual(len(objects), 1)
         self.assertTrue(isinstance(objects, QuerySet))
         self.assertEqual(set(objects.values_list("pk", flat=True)), {obj_with_uuid_pk.pk})
+
+    def test_joined_queryset_with_cast_primary_key(self):
+        assign_perm("auth.change_group", self.user, self.group)
+
+        objects = get_objects_for_user(
+            self.user,
+            "auth.change_group",
+            Group.objects.filter(user__isnull=True),
+        )
+
+        self.assertEqual(set(objects.values_list("pk", flat=True)), {self.group.pk})
+
+    def test_filter_perms_queryset_by_joined_objects(self):
+        assign_perm("auth.change_group", self.user, self.group)
+
+        perms = filter_perms_queryset_by_objects(
+            UserObjectPermission.objects.filter(user=self.user),
+            Group.objects.filter(user__isnull=True),
+        )
+
+        self.assertEqual(set(perms.values_list("object_pk", flat=True)), {str(self.group.pk)})
 
     def test_varchar_primary_key_with_any_perm(self):
         """


### PR DESCRIPTION
## Summary

Fix `filter_perms_queryset_by_objects` so object querysets with existing joins still produce a single-column subquery for `__in` lookups.

The generic-object branch previously used `.values(_pk=...)`, and joined querysets can keep extra selected columns in that subquery, causing:

```text
ValueError: The QuerySet value for the 'in' lookup must have 1 selected fields
```

This changes the object primary-key subqueries to use `.values_list(..., flat=True)` after annotating the transformed primary key.

There is a nearby open PR (#990) for the bigint/object_pk cast regression, but it does not cover this joined-queryset failure mode and still uses `.values(...)` in this function.

## Test plan

- `.\.venv\Scripts\python.exe -m pytest guardian\testapp\tests\test_shortcuts.py::GetObjectsForUser::test_joined_queryset_with_cast_primary_key guardian\testapp\tests\test_shortcuts.py::GetObjectsForUser::test_filter_perms_queryset_by_joined_objects guardian\testapp\tests\test_shortcuts.py::GetObjectsForUser::test_uuid_primary_key guardian\testapp\tests\test_shortcuts.py::GetObjectsForUser::test_varchar_primary_key -q` -> `4 passed`
- `python -m ruff check guardian\shortcuts.py guardian\testapp\tests\test_shortcuts.py`
- `python -m ruff format --check guardian\shortcuts.py guardian\testapp\tests\test_shortcuts.py`
- `git diff --cached --check` before commit

Fixes #992.