### PR TITLE
Fix attached permissions when groups are excluded

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -435,8 +435,7 @@ def get_users_with_perms(
             only_with_perms_in=only_with_perms_in,
             with_superusers=with_superusers,
         ):
-            # TODO: Support the case of set with_group_users but not with_superusers.
-            if with_group_users or with_superusers:
+            if with_group_users or (with_superusers and user.is_superuser):
                 users[user] = sorted(get_perms(user, obj))
             else:
                 users[user] = sorted(get_user_perms(user, obj))

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -854,6 +854,28 @@ class GetUsersWithPermsTest(TestCase):
         expected = {self.user1: ["change_contenttype"], admin: ["delete_contenttype"]}
         self.assertEqual(result, expected)
 
+    def test_without_group_users_with_superusers_and_perms_attached(self):
+        admin = User.objects.create(username="admin", is_superuser=True)
+        self.user1.groups.add(self.group1)
+        self.user2.groups.add(self.group1)
+        assign_perm("change_contenttype", self.user1, self.obj1)
+        assign_perm("delete_contenttype", self.group1, self.obj1)
+
+        result = get_users_with_perms(self.obj1, attach_perms=True, with_superusers=True, with_group_users=False)
+        expected = {
+            self.user1: ["change_contenttype"],
+            admin: [
+                "add_contenttype",
+                "change_contenttype",
+                "delete_contenttype",
+                "view_contenttype",
+            ],
+        }
+
+        self.assertEqual(result.keys(), expected.keys())
+        for key, perms in result.items():
+            self.assertEqual(set(perms), set(expected[key]))
+
     def test_without_group_users_no_result(self):
         self.user1.groups.add(self.group1)
         assign_perm("change_contenttype", self.group1, self.obj1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ authors = [
   { name = "Cornelius Hoffmann", email = "coding@volucra.de" },
   { name = "Sezer BOZKIR", email = "admin@sezerbozkir.com"},
   { name = "Paul Martin", email = "pauledwardmartin91@gmail.com"},
+  { name = "marko1olo", email = "barsukdana@gmail.com" },
 ]
 maintainers = [
   {name = "Tom Clark", email = "django-guardian@octue.com"},


### PR DESCRIPTION
## Summary
- respect `with_group_users=False` when `attach_perms=True` and `with_superusers=True` are used together
- keep full permission lists for included superusers
- add regression coverage for a direct-permission user who also belongs to a permitted group
- add the configured git identity to `pyproject.toml` per the contribution guide

## Tests
- `.\.venv\Scripts\python.exe -m pytest guardian\testapp\tests\test_shortcuts.py::GetUsersWithPermsTest::test_without_group_users_with_superusers_and_perms_attached guardian\testapp\tests\test_shortcuts.py::GetUsersWithPermsTest::test_direct_perms_only_perms_attached guardian\testapp\tests\test_shortcuts.py::GetUsersWithPermsTest::test_without_group_users_no_result_but_with_superusers -q`
- `.\.venv\Scripts\python.exe -m pytest guardian\testapp\tests\test_shortcuts.py -q`
- `.\.venv\Scripts\python.exe -m pytest guardian\testapp\tests\test_direct_rel.py -q`
- `.\.venv\Scripts\ruff.exe check guardian\shortcuts.py guardian\testapp\tests\test_shortcuts.py`
- `.\.venv\Scripts\ruff.exe format --check guardian\shortcuts.py guardian\testapp\tests\test_shortcuts.py`
- `PYTHONPYCACHEPREFIX=C:\tmp\pycache-django-guardian-superuser-perms .\.venv\Scripts\python.exe -m compileall -q guardian\shortcuts.py guardian\testapp\tests\test_shortcuts.py`
- `git diff --check`

Notes: pytest/ruff cache writes emitted local Windows access-denied cache warnings in this sandbox, but the test and lint assertions above passed.