### PR TITLE
Avoid external Actions badge in testing docs

### DIFF
--- a/docs/develop/testing.md
+++ b/docs/develop/testing.md
@@ -121,7 +121,5 @@ environments and pull dependencies) but would ensure everything is fine.
 
 !!! abstract "Added in version 2.4.0"
 
-[![image](https://github.com/django-guardian/django-guardian/workflows/Tests/badge.svg?branch=devel)](https://github.com/django-guardian/django-guardian/actions/workflows/tests.yml)
-
 We have support for [GitHub Actions](https://github.com/django-guardian/django-guardian/actions)
 to make it easy to follow if test fails with new commits.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ authors = [
   { name = "Cornelius Hoffmann", email = "coding@volucra.de" },
   { name = "Sezer BOZKIR", email = "admin@sezerbozkir.com"},
   { name = "Paul Martin", email = "pauledwardmartin91@gmail.com"},
+  { name = "marko1olo", email = "barsukdana@gmail.com" },
 ]
 maintainers = [
   {name = "Tom Clark", email = "django-guardian@octue.com"},


### PR DESCRIPTION
## Summary
- Remove the remote GitHub Actions badge image from the testing docs.
- Keep the existing GitHub Actions text link for contributor navigation.
- Avoid letting MkDocs Material's privacy plugin fail docs builds when the external badge SVG cannot be cached.

This is the same external badge-fetch failure currently visible in ReadTheDocs on #995.

## Tests
- `rg -n "badge\.svg|!\[.*github\.com/.*/actions|workflows/.*/badge" docs mkdocs.yml` returned no matches
- `python -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8'))"`
- `python -m mkdocs build --site-dir .site-tmp`
- `python -m mkdocs build --strict --site-dir .site-tmp` reached docs rendering without the badge fetch; it still aborts on existing strict warnings from Material/griffe, unrelated to this badge removal