### PR TITLE
Add opt-in ReinforcedGuardedModelAdminMixin

### DIFF
--- a/docs/api/admin.md
+++ b/docs/api/admin.md
@@ -3,3 +3,7 @@
 ::: guardian.admin.GuardedModelAdmin
 
 ::: guardian.admin.GuardedModelAdminMixin
+
+::: guardian.admin.ReinforcedGuardedModelAdmin
+
+::: guardian.admin.ReinforcedGuardedModelAdminMixin

--- a/docs/userguide/admin-integration.md
+++ b/docs/userguide/admin-integration.md
@@ -90,6 +90,37 @@ row level permissions.
 !!! note
     Example above is shipped with `django-guardian` package with the example project.
 
+## Restricting Access to the Object Permissions Views
+
+`GuardedModelAdmin` only requires the standard Django change permission for
+the model itself to access the object permissions management views. Any
+staff user allowed to change a `Post`, for example, can also view and edit
+*every* user's and group's guardian permissions for it, whether or not they
+hold a guardian permission for that.
+
+If you want those views to also require the relevant guardian permission
+(`guardian.view_userobjectpermission`, `guardian.view_groupobjectpermission`,
+`guardian.change_userobjectpermission`, or `guardian.change_groupobjectpermission`,
+depending on the view), use `ReinforcedGuardedModelAdmin` instead:
+
+``` python
+from guardian.admin import ReinforcedGuardedModelAdmin
+
+
+class PostAdmin(ReinforcedGuardedModelAdmin):
+    prepopulated_fields = {"slug": ("title",)}
+    list_display = ('title', 'slug', 'created_at')
+    search_fields = ('title', 'content')
+    ordering = ('-created_at',)
+    date_hierarchy = 'created_at'
+
+admin.site.register(Post, PostAdmin)
+```
+
+This is opt-in and not the default, since some applications may rely on the
+existing behavior of granting access based on the model's change permission
+alone.
+
 ## Inline Admin Support
 
 Django admin provides inline functionality that allows editing related objects

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -424,6 +424,40 @@ class GuardedModelAdminMixin:
         return AdminGroupObjectPermissionsForm
 
 
+class ReinforcedGuardedModelAdminMixin(GuardedModelAdminMixin):
+    """Mixin helper for custom subclassing `admin.ModelAdmin`.
+
+    Like `GuardedModelAdminMixin`, but also requires the guardian
+    view/change permissions for the object permissions management views
+    themselves. `GuardedModelAdminMixin` only checks `has_change_permission`
+    for the underlying model, so any staff user allowed to change a model
+    instance can also view and edit *every* user's and group's object
+    permissions for it, whether or not they hold the guardian permission
+    for that. This mixin is opt-in to avoid changing the behavior of
+    existing `GuardedModelAdminMixin` subclasses.
+    """
+
+    def obj_perms_manage_view(self, request, object_pk):
+        if not request.user.has_perm("guardian.view_userobjectpermission") and not request.user.has_perm(
+            "guardian.view_groupobjectpermission"
+        ):
+            post_url = reverse("admin:index", current_app=self.admin_site.name)
+            return redirect(post_url)
+        return super().obj_perms_manage_view(request, object_pk)
+
+    def obj_perms_manage_user_view(self, request, object_pk, user_id):
+        if not request.user.has_perm("guardian.change_userobjectpermission"):
+            post_url = reverse("admin:index", current_app=self.admin_site.name)
+            return redirect(post_url)
+        return super().obj_perms_manage_user_view(request, object_pk, user_id)
+
+    def obj_perms_manage_group_view(self, request, object_pk, group_id):
+        if not request.user.has_perm("guardian.change_groupobjectpermission"):
+            post_url = reverse("admin:index", current_app=self.admin_site.name)
+            return redirect(post_url)
+        return super().obj_perms_manage_group_view(request, object_pk, group_id)
+
+
 class GuardedModelAdmin(GuardedModelAdminMixin, admin.ModelAdmin):
     """Provide views for managing object permissions on the Django admin panel.
 
@@ -472,6 +506,14 @@ class GuardedModelAdmin(GuardedModelAdminMixin, admin.ModelAdmin):
 
         admin.site.register(Author, AuthorAdmin)
         ```
+    """
+
+
+class ReinforcedGuardedModelAdmin(ReinforcedGuardedModelAdminMixin, admin.ModelAdmin):
+    """Like `GuardedModelAdmin`, but requires the guardian view/change
+    permissions for the object permissions management views themselves.
+
+    See `ReinforcedGuardedModelAdminMixin` for details.
     """
 
 

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -438,7 +438,12 @@ class ReinforcedGuardedModelAdminMixin(GuardedModelAdminMixin):
     """
 
     def obj_perms_manage_view(self, request, object_pk):
-        if not request.user.has_perm("guardian.view_userobjectpermission") and not request.user.has_perm(
+        # The delegated view always renders both users_perms and
+        # groups_perms on the same page, with no way to omit either half,
+        # so reaching it requires both view permissions. Requiring just
+        # one would let a user who can only view user-object permissions
+        # see every group's object permissions too, and vice versa.
+        if not request.user.has_perm("guardian.view_userobjectpermission") or not request.user.has_perm(
             "guardian.view_groupobjectpermission"
         ):
             post_url = reverse("admin:index", current_app=self.admin_site.name)

--- a/guardian/testapp/tests/test_admin.py
+++ b/guardian/testapp/tests/test_admin.py
@@ -7,17 +7,18 @@ from django import forms
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.http import HttpRequest
 from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 
-from guardian.admin import GuardedInlineAdminMixin, GuardedModelAdmin
+from guardian.admin import GuardedInlineAdminMixin, GuardedModelAdmin, ReinforcedGuardedModelAdmin
 from guardian.models import Group
 from guardian.shortcuts import assign_perm, get_perms, get_perms_for_model, remove_perm
 from guardian.testapp.models import LogEntryWithGroup as LogEntry
-from guardian.testapp.models import UserProfile
+from guardian.testapp.models import Post, UserProfile
 from guardian.testapp.tests.conf import skipUnlessTestApp
 
 User = get_user_model()
@@ -47,6 +48,12 @@ try:
 except admin.sites.NotRegistered:
     pass
 admin.site.register(ContentType, ContentTypeGuardedAdmin)
+
+try:
+    admin.site.unregister(Post)
+except admin.sites.NotRegistered:
+    pass
+admin.site.register(Post, ReinforcedGuardedModelAdmin)
 
 
 class AdminTests(TestCase):
@@ -431,6 +438,64 @@ class GuardedModelAdminTests(TestCase):
         request.user = joe
         qs = gma.get_queryset(request)
         self.assertEqual(sorted(e.pk for e in qs), sorted(LogEntry.objects.values_list("pk", flat=True)))
+
+
+class ReinforcedGuardedModelAdminTests(TestCase):
+    """Object permissions management views must require the guardian
+    view/change permission, not just the model's own change permission.
+    """
+
+    def setUp(self):
+        self.staffer = User.objects.create_user("staffer", "staffer@example.com", "staffer")
+        self.staffer.is_staff = True
+        self.staffer.user_permissions.add(
+            Permission.objects.get(
+                content_type=ContentType.objects.get_for_model(Post),
+                codename="change_post",
+            )
+        )
+        self.staffer.save()
+        self.post = Post.objects.create(title="foo-post-title")
+        self.client = Client()
+        self.client.login(username="staffer", password="staffer")
+
+    def tearDown(self):
+        self.client.logout()
+
+    def test_manage_view_denies_staff_without_guardian_perm(self):
+        url = reverse("admin:testapp_post_permissions", args=[self.post.pk])
+        response = self.client.get(url)
+        self.assertRedirects(response, reverse("admin:index"))
+
+    def test_manage_view_allows_staff_with_guardian_perm(self):
+        self.staffer.user_permissions.add(Permission.objects.get(codename="view_userobjectpermission"))
+        url = reverse("admin:testapp_post_permissions", args=[self.post.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_manage_user_view_denies_staff_without_guardian_perm(self):
+        url = reverse("admin:testapp_post_permissions_manage_user", args=[self.post.pk, self.staffer.pk])
+        response = self.client.get(url)
+        self.assertRedirects(response, reverse("admin:index"))
+
+    def test_manage_user_view_allows_staff_with_guardian_perm(self):
+        self.staffer.user_permissions.add(Permission.objects.get(codename="change_userobjectpermission"))
+        url = reverse("admin:testapp_post_permissions_manage_user", args=[self.post.pk, self.staffer.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_manage_group_view_denies_staff_without_guardian_perm(self):
+        group = Group.objects.create(name="reinforced-test-group")
+        url = reverse("admin:testapp_post_permissions_manage_group", args=[self.post.pk, group.pk])
+        response = self.client.get(url)
+        self.assertRedirects(response, reverse("admin:index"))
+
+    def test_manage_group_view_allows_staff_with_guardian_perm(self):
+        self.staffer.user_permissions.add(Permission.objects.get(codename="change_groupobjectpermission"))
+        group = Group.objects.create(name="reinforced-test-group")
+        url = reverse("admin:testapp_post_permissions_manage_group", args=[self.post.pk, group.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
 
 
 class GrappelliGuardedModelAdminTests(TestCase):

--- a/guardian/testapp/tests/test_admin.py
+++ b/guardian/testapp/tests/test_admin.py
@@ -467,8 +467,27 @@ class ReinforcedGuardedModelAdminTests(TestCase):
         response = self.client.get(url)
         self.assertRedirects(response, reverse("admin:index"))
 
-    def test_manage_view_allows_staff_with_guardian_perm(self):
+    def test_manage_view_denies_staff_with_only_user_view_perm(self):
+        # The combined page always renders both users_perms and
+        # groups_perms, so holding only the user-side view permission
+        # must not be enough to reach it: it would expose every group's
+        # object permissions too.
         self.staffer.user_permissions.add(Permission.objects.get(codename="view_userobjectpermission"))
+        url = reverse("admin:testapp_post_permissions", args=[self.post.pk])
+        response = self.client.get(url)
+        self.assertRedirects(response, reverse("admin:index"))
+
+    def test_manage_view_denies_staff_with_only_group_view_perm(self):
+        # Symmetric case: only the group-side view permission must not
+        # expose every user's object permissions either.
+        self.staffer.user_permissions.add(Permission.objects.get(codename="view_groupobjectpermission"))
+        url = reverse("admin:testapp_post_permissions", args=[self.post.pk])
+        response = self.client.get(url)
+        self.assertRedirects(response, reverse("admin:index"))
+
+    def test_manage_view_allows_staff_with_both_guardian_perms(self):
+        self.staffer.user_permissions.add(Permission.objects.get(codename="view_userobjectpermission"))
+        self.staffer.user_permissions.add(Permission.objects.get(codename="view_groupobjectpermission"))
         url = reverse("admin:testapp_post_permissions", args=[self.post.pk])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Related to #756.

GuardedModelAdminMixin only checks has_change_permission on the underlying model for its object permissions management views. Any staff user allowed to change a model instance can view and edit every user's and group's guardian permissions for it, even without the guardian view/change permission for that.

A previous fix for this changed the default behavior and was reverted (#757, #764), since some applications might rely on it and the change wasn't something everyone agreed should be forced on all users of GuardedModelAdminMixin. This adds the same check as an opt-in mixin instead. Existing GuardedModelAdminMixin/GuardedModelAdmin subclasses are unaffected.

ReinforcedGuardedModelAdminMixin and ReinforcedGuardedModelAdmin wrap each of the three object permission views with the matching guardian permission check before delegating to the base implementation. Added tests covering both the denied and allowed case for all three views, plus a docs section and API reference entries.

Ran the full admin test suite (56 passed) and ruff. I also temporarily removed the permission checks and confirmed the new tests then fail (302 expected, got 200). That confirms they actually exercise the fix rather than just checking the class exists.