### PR TITLE
Add Django 6.0 support

### DIFF
--- a/guardian/testapp/tests/test_orphans.py
+++ b/guardian/testapp/tests/test_orphans.py
@@ -37,8 +37,12 @@ class OrphanedObjectPermissionsTest(TestCase):
         """Helper method to create a specific number of orphan permissions"""
         target_objs = []
         for i in range(count):
+            # Use only the test method name (not self.id(), whose fully qualified
+            # dotted path can exceed ContentType.model's max_length=100 and raise
+            # a DataError on strict backends like PostgreSQL/MySQL, even though
+            # SQLite silently accepts it).
             target_obj = ContentType.objects.create(
-                model=f"test_model_{self.id()}_{i}", app_label="fake-for-guardian-tests"
+                model=f"test_model_{self._testMethodName}_{i}", app_label="fake-for-guardian-tests"
             )
             target_objs.append(target_obj)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     'Framework :: Django :: 5.0',
     'Framework :: Django :: 5.1',
     'Framework :: Django :: 5.2',
+    'Framework :: Django :: 6.0',
     'Programming Language :: Python',
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     core-py{310,311,312}-{django50},
     core-py{310,311,312,313}-{django51},
     core-py{310,311,312,313,314}-{django52},
+    core-py{312,313,314}-{django60},
     core-py{312,313,314}-{djangomain},
     {example,examplegroup}-{py313}-{django51},
     docs-{py313}-{django51},
@@ -13,9 +14,9 @@ envlist =
 python =
     3.10 = core-py310-{django42,django50,django51,django52}, type-py310
     3.11 = core-py311-{django42,django50,django51,django52}, type-py311
-    3.12 = core-py312-{django50,django51,django52,djangomain}, type-py312
-    3.13 = core-py313-{django51,django52,djangomain}, examplegroup-py313-django51, docs-py313-django51, type-py313
-    3.14 = core-py314-{django52,djangomain}, type-py314
+    3.12 = core-py312-{django50,django51,django52,django60,djangomain}, type-py312
+    3.13 = core-py313-{django51,django52,django60,djangomain}, examplegroup-py313-django51, docs-py313-django51, type-py313
+    3.14 = core-py314-{django52,django60,djangomain}, type-py314
 
 
 [testenv]
@@ -41,6 +42,7 @@ commands =
     django50: python {toxinidir}/manage.py makemigrations --check --dry-run
     django51: python {toxinidir}/manage.py makemigrations --check --dry-run
     django52: python {toxinidir}/manage.py makemigrations --check --dry-run
+    django60: python {toxinidir}/manage.py makemigrations --check --dry-run
     djangomain: python {toxinidir}/manage.py makemigrations --check --dry-run
     type: mypy ./guardian
     core: pytest --cov=guardian --cov-report=xml
@@ -56,4 +58,5 @@ deps =
     django50: django>=5.0,<5.1
     django51: django>=5.1,<5.2
     django52: django>=5.2,<5.3
+    django60: django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
This pull request adds support for Django 6.0 to the project. The changes update the test matrix, dependencies, and classifiers to ensure compatibility and proper testing with Django 6.0 across supported Python versions.

**Django 6.0 Support**

* Added `Django 6.0` to the `classifiers` list in `pyproject.toml` to indicate official support.
* Updated the `tox.ini` test matrix to include Django 6.0 environments for Python 3.12, 3.13, and 3.14. [[1]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R7) [[2]](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449L16-R19)
* Added a `django60` dependency group in `tox.ini` to specify the correct Django version range.
* Configured the `makemigrations` check command for the new `django60` environment in `tox.ini`.