### PR TITLE
Fix queryset filtering with annotations in get_objects_for_user

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -984,17 +984,11 @@ def filter_perms_queryset_by_objects(perms_queryset, objects):
                 if _casts_to_bigint(handle_pk_field):
                     # Keep object_pk untouched to avoid CAST(object_pk AS bigint)
                     # scans on large guardian tables. We only stringify model PKs.
-                    objects = (
-                        objects.annotate(_pk=Cast("pk", output_field=CharField())).values_list(
-                            "_pk", flat=True
-                        )
-                    )
+                    objects = objects.annotate(_pk=Cast("pk", output_field=CharField())).values_list("_pk", flat=True)
                     field = "object_pk"
                 else:
-                    objects = (
-                        objects.annotate(
-                            _pk=Cast(handle_pk_field("pk"), output_field=CharField())
-                        ).values_list("_pk", flat=True)
+                    objects = objects.annotate(_pk=Cast(handle_pk_field("pk"), output_field=CharField())).values_list(
+                        "_pk", flat=True
                     )
                     # Apply the same transformation to the object_pk field for consistent comparison (#930)
                     perms_queryset = perms_queryset.annotate(

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -984,19 +984,27 @@ def filter_perms_queryset_by_objects(perms_queryset, objects):
                 if _casts_to_bigint(handle_pk_field):
                     # Keep object_pk untouched to avoid CAST(object_pk AS bigint)
                     # scans on large guardian tables. We only stringify model PKs.
-                    objects = objects.values(_pk=Cast("pk", output_field=CharField()))
+                    objects = (
+                        objects.annotate(_pk=Cast("pk", output_field=CharField())).values_list(
+                            "_pk", flat=True
+                        )
+                    )
                     field = "object_pk"
                 else:
-                    objects = objects.values(_pk=Cast(handle_pk_field("pk"), output_field=CharField()))
+                    objects = (
+                        objects.annotate(
+                            _pk=Cast(handle_pk_field("pk"), output_field=CharField())
+                        ).values_list("_pk", flat=True)
+                    )
                     # Apply the same transformation to the object_pk field for consistent comparison (#930)
                     perms_queryset = perms_queryset.annotate(
                         _transformed_object_pk=Cast(handle_pk_field(field), output_field=CharField())
                     )
                     field = "_transformed_object_pk"
             else:
-                objects = objects.values("pk")
+                objects = objects.values_list("pk", flat=True)
         else:
-            objects = objects.values("pk")
+            objects = objects.values_list("pk", flat=True)
         return perms_queryset.filter(**{"{}__in".format(field): objects})
     else:
         return perms_queryset

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -6,6 +6,7 @@ import django
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import IntegerField, Value
 from django.db.models.query import QuerySet
 from django.test import TestCase, TransactionTestCase
 
@@ -1108,6 +1109,14 @@ class GetObjectsForUser(TestCase):
 
         query = str(objects.query).lower()
         assert_query_does_not_cast_object_pk(self, query)
+
+    def test_get_objects_for_user_with_annotated_queryset_klass(self):
+        assign_perm("auth.change_group", self.user, self.group)
+        other_group = Group.objects.create(name="group2")
+        qs = Group.objects.annotate(_dummy=Value(1, output_field=IntegerField()))
+        objects = get_objects_for_user(self.user, ["auth.change_group"], qs)
+        self.assertEqual(set(objects), {self.group})
+        self.assertNotIn(other_group, objects)
 
     def test_ensure_returns_queryset(self):
         objects = get_objects_for_user(self.user, ["auth.change_group"])

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -1110,7 +1110,7 @@ class GetObjectsForUser(TestCase):
         query = str(objects.query).lower()
         assert_query_does_not_cast_object_pk(self, query)
 
-    def test_get_objects_for_user_with_annotated_queryset_klass(self):
+    def test_get_objects_for_user_with_annotated_queryset(self):
         assign_perm("auth.change_group", self.user, self.group)
         other_group = Group.objects.create(name="group2")
         qs = Group.objects.annotate(_dummy=Value(1, output_field=IntegerField()))


### PR DESCRIPTION
## Description

Fixes #992.

When `get_objects_for_user()` receives a queryset containing existing annotations or joins, the queryset is used as a subquery for an `__in` lookup.

The previous use of `.values()` could result in multiple selected fields in the subquery, causing Django to raise:

> The QuerySet value for the 'in' lookup must have 1 selected fields

This change explicitly projects the transformed primary key using `.values_list(..., flat=True)`.

## Changes

- Replace transformed `.values()` calls with `.annotate(...).values_list(..., flat=True)`.
- Replace plain `.values("pk")` with `.values_list("pk", flat=True)`.
- Add a regression test covering an annotated queryset passed to `get_objects_for_user()`.

## Testing

- `guardian/testapp/tests/test_shortcuts.py` — 173 passed
- `guardian/testapp/tests/test_core.py guardian/testapp/tests/test_managers.py` — 36 passed
- `git diff --check` — passed

The full test suite was not completed locally because it exceeded the execution timeout on Windows.