### PR TITLE
Enable pyupgrade --py310-plus, coherent with requires-python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,4 @@ repos:
   rev: v3.20.0
   hooks:
   - id: pyupgrade
+    args: [--py310-plus]

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -79,7 +79,7 @@ class Timed:
                 call.finish = datetime.datetime.now()
                 func.calls.append(call)
                 if self.action:
-                    print(" -> [{}] Done (Total time: {})".format(self.action, call.delta()))
+                    print(f" -> [{self.action}] Done (Total time: {call.delta()})")
 
         return wrapper
 

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -16,7 +16,7 @@ def show_settings(settings, action):
             value = "****************"
         else:
             value = db_conf[key]
-        line = '    {}: "{}"'.format(key, value)
+        line = f'    {key}: "{value}"'
         output.append(line)
     embracer = colorize("=" * len(max(output, key=lambda s: len(s))), fg="green", opts=["bold"])
     output = [colorize(line, fg="blue") for line in output]

--- a/example_project_custom_group/core/models.py
+++ b/example_project_custom_group/core/models.py
@@ -63,7 +63,7 @@ class CustomUser(AbstractBaseUser, CustomGroupPermissionsMixin, GuardianUserMixi
         """
         Return the first_name plus the last_name, with a space in between.
         """
-        full_name = "{} {}".format(self.first_name, self.last_name)
+        full_name = f"{self.first_name} {self.last_name}"
         return full_name.strip()
 
     def get_short_name(self):

--- a/guardian/admin.py
+++ b/guardian/admin.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from typing import Type
 
 from django import forms
 from django.conf import settings
@@ -327,7 +326,7 @@ class GuardedModelAdminMixin:
             return "admin/guardian/contrib/grappelli/obj_perms_manage_user.html"
         return self.obj_perms_manage_user_template
 
-    def get_obj_perms_user_select_form(self, request: HttpRequest) -> Type[forms.Form]:
+    def get_obj_perms_user_select_form(self, request: HttpRequest) -> type[forms.Form]:
         """Get the form class for selecting a user for permissions management.
 
         Parameters:
@@ -339,7 +338,7 @@ class GuardedModelAdminMixin:
         """
         return UserManage
 
-    def get_obj_perms_group_select_form(self, request: HttpRequest) -> Type[forms.Form]:
+    def get_obj_perms_group_select_form(self, request: HttpRequest) -> type[forms.Form]:
         """Get the form class for group object permissions management.
         Parameters:
             request (HttpRequest): The HTTP request object.
@@ -350,7 +349,7 @@ class GuardedModelAdminMixin:
         """
         return GroupManage
 
-    def get_obj_perms_manage_user_form(self, request: HttpRequest) -> Type[forms.Form]:
+    def get_obj_perms_manage_user_form(self, request: HttpRequest) -> type[forms.Form]:
         """Get the form class for user object permissions management.
 
         Parameters:

--- a/guardian/backends.py
+++ b/guardian/backends.py
@@ -1,4 +1,5 @@
-from typing import Any, Iterable, Optional
+from collections.abc import Iterable
+from typing import Any
 
 from django.contrib.auth import get_user_model
 from django.db import models
@@ -62,10 +63,10 @@ class ObjectPermissionBackend:
     supports_anonymous_user = True
     supports_inactive_user = True
 
-    def authenticate(self, request: HttpRequest, username: Optional[str] = None, password: Optional[str] = None) -> Any:
+    def authenticate(self, request: HttpRequest, username: str | None = None, password: str | None = None) -> Any:
         return None
 
-    def has_perm(self, user_obj: Any, perm: str, obj: Optional[Model] = None) -> bool:
+    def has_perm(self, user_obj: Any, perm: str, obj: Model | None = None) -> bool:
         """Check if a user has the permission for a given object.
 
         Returns `True` if given `user_obj` has `perm` for `obj`.
@@ -105,15 +106,15 @@ class ObjectPermissionBackend:
                 ctype = get_content_type(obj)
                 if app_label != ctype.app_label:
                     raise WrongAppError(
-                        "Passed perm has app label of '%s' while "
-                        "given obj has app label '%s' and given obj"
-                        "content_type has app label '%s'" % (app_label, obj._meta.app_label, ctype.app_label)  # type: ignore[union-attr]
+                        f"Passed perm has app label of '{app_label}' while "
+                        f"given obj has app label '{obj._meta.app_label}' and given obj"  # type: ignore[union-attr]
+                        f"content_type has app label '{ctype.app_label}'"
                     )
 
         check = ObjectPermissionChecker(user_obj)
         return check.has_perm(perm, obj)
 
-    def get_group_permissions(self, user_obj: Any, obj: Optional[Model] = None) -> Iterable[str]:
+    def get_group_permissions(self, user_obj: Any, obj: Model | None = None) -> Iterable[str]:
         """Returns group permissions for a given object.
 
         Parameters:
@@ -137,7 +138,7 @@ class ObjectPermissionBackend:
         check = ObjectPermissionChecker(user_obj)
         return set(check.get_group_perms(obj))
 
-    def get_all_permissions(self, user_obj: Any, obj: Optional[Model] = None) -> Iterable[str]:
+    def get_all_permissions(self, user_obj: Any, obj: Model | None = None) -> Iterable[str]:
         """Returns all permissions for a given object.
 
         Parameters:

--- a/guardian/compat.py
+++ b/guardian/compat.py
@@ -46,7 +46,7 @@ def get_user_permission_full_codename(perm: str) -> str:
     """
     user_model = get_user_model()
     model_name = user_model._meta.model_name
-    return "{}.{}_{}".format(user_model._meta.app_label, perm, model_name)
+    return f"{user_model._meta.app_label}.{perm}_{model_name}"
 
 
 def get_user_permission_codename(perm: str) -> str:

--- a/guardian/core.py
+++ b/guardian/core.py
@@ -1,5 +1,5 @@
+from collections.abc import Iterable
 from itertools import chain
-from typing import Iterable, Optional
 
 from django.contrib.auth.models import Permission
 from django.db.models import Model
@@ -53,7 +53,7 @@ class ObjectPermissionChecker:
        dictionary.
     """
 
-    def __init__(self, user_or_group: Optional[Model] = None) -> None:
+    def __init__(self, user_or_group: Model | None = None) -> None:
         """Constructor for ObjectPermissionChecker.
 
         Parameters:

--- a/guardian/ctypes.py
+++ b/guardian/ctypes.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, Union
+from typing import Any
 
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Model
@@ -7,12 +7,12 @@ from django.utils.module_loading import import_string
 from guardian.conf import settings as guardian_settings
 
 
-def get_content_type(obj: Union[Model, Type[Model]]) -> Any:
+def get_content_type(obj: Model | type[Model]) -> Any:
     get_content_type_function = import_string(guardian_settings.GET_CONTENT_TYPE)
     return get_content_type_function(obj)
 
 
-def get_default_content_type(obj: Union[Model, Type[Model]]) -> ContentType:
+def get_default_content_type(obj: Model | type[Model]) -> ContentType:
     """Get content type for a given object using Django's content type framework.
 
     Parameters:

--- a/guardian/ctypes.py
+++ b/guardian/ctypes.py
@@ -16,7 +16,7 @@ def get_default_content_type(obj: Model | type[Model]) -> ContentType:
     """Get content type for a given object using Django's content type framework.
 
     Parameters:
-        obj (Model | Type): Object for which content type is to be fetched.
+        obj (Model | type[Model]): Object for which content type is to be fetched.
 
     Returns:
         Content type for the given object.

--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -1,4 +1,4 @@
-from typing import Any, TypeAlias, Union
+from typing import Any, TypeAlias
 import warnings
 
 from django.contrib.auth.models import Permission
@@ -12,7 +12,7 @@ from guardian.core import ObjectPermissionChecker
 from guardian.ctypes import get_content_type, get_default_content_type
 from guardian.exceptions import ObjectNotPersisted
 
-_PermType: TypeAlias = Union[Permission, str]
+_PermType: TypeAlias = Permission | str
 
 _DEFAULT_CONTENT_TYPE_PATH = f"{get_default_content_type.__module__}.{get_default_content_type.__name__}"
 
@@ -41,9 +41,7 @@ def _ensure_permission(perm: _PermType, ctype: ContentType) -> Permission:
     return perm
 
 
-def _get_perm_filter(
-    perm: _PermType, model: Union[Model, type[Model], None] = None, ctype: Union[ContentType, None] = None
-) -> Q:
+def _get_perm_filter(perm: _PermType, model: Model | type[Model] | None = None, ctype: ContentType | None = None) -> Q:
     if isinstance(perm, Permission):
         return Q(permission=perm)
 
@@ -89,7 +87,7 @@ class BaseObjectPermissionManager(models.Manager):
         return obj_perm
 
     def bulk_assign_perm(
-        self, perm: _PermType, user_or_group: Any, queryset: Union[QuerySet, list], ignore_conflicts: bool = False
+        self, perm: _PermType, user_or_group: Any, queryset: QuerySet | list, ignore_conflicts: bool = False
     ) -> list:
         """
         Bulk assigns permissions with given `perm` for an objects in `queryset` and
@@ -171,9 +169,7 @@ class BaseObjectPermissionManager(models.Manager):
             filters &= Q(content_object__pk=obj.pk)
         return self.filter(filters).delete()
 
-    def bulk_remove_perm(
-        self, perm: _PermType, user_or_group: Any, queryset: Union[QuerySet, list]
-    ) -> tuple[int, dict]:
+    def bulk_remove_perm(self, perm: _PermType, user_or_group: Any, queryset: QuerySet | list) -> tuple[int, dict]:
         """
         Removes permission `perm` for a `queryset` and given `user_or_group`.
 

--- a/guardian/mixins.py
+++ b/guardian/mixins.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 import sys
 from types import GeneratorType
-from typing import Any, Optional, Union
+from typing import Any
 import warnings
 
 # Import deprecated decorator with fallback for Python < 3.13
@@ -135,7 +135,7 @@ class PermissionRequiredMixin:
 
     # default class view settings
     login_url: str = settings.LOGIN_URL
-    permission_required: Union[str, list[str], None] = None
+    permission_required: str | list[str] | None = None
     redirect_field_name: str = REDIRECT_FIELD_NAME
     return_403: bool = False
     return_404: bool = False
@@ -151,7 +151,7 @@ class PermissionRequiredMixin:
         """
         return self.object_permission_denied_message
 
-    def get_required_permissions(self, request: Optional[HttpRequest] = None) -> list[str]:
+    def get_required_permissions(self, request: HttpRequest | None = None) -> list[str]:
         """Get the required permissions.
 
         Returns list of permissions in format *<app_label>.<codename>* that
@@ -190,7 +190,7 @@ class PermissionRequiredMixin:
 
     def check_permissions(
         self, request: HttpRequest
-    ) -> Union[HttpResponseForbidden, HttpResponseNotFound, HttpResponseRedirect, HttpResponse, None]:
+    ) -> HttpResponseForbidden | HttpResponseNotFound | HttpResponseRedirect | HttpResponse | None:
         """Check if the user has the required permissions.
 
         Checks if `request.user` has all permissions returned by the
@@ -220,7 +220,7 @@ class PermissionRequiredMixin:
         return forbidden
 
     def on_permission_check_fail(
-        self, request: HttpRequest, response: HttpResponse, obj: Optional[Union[Model, Any]] = None
+        self, request: HttpRequest, response: HttpResponse, obj: Model | Any | None = None
     ) -> None:
         """Method called upon permission check fail.
 
@@ -301,11 +301,11 @@ class PermissionListMixin:
             Default to `{}`,
     """
 
-    permission_required: Union[str, list[str], None] = None
+    permission_required: str | list[str] | None = None
     # rename get_objects_for_user_kwargs to when get_get_objects_for_user_kwargs is removed
     get_objects_for_user_extra_kwargs: dict = {}
 
-    def get_required_permissions(self, request: Optional[HttpRequest] = None) -> list[str]:
+    def get_required_permissions(self, request: HttpRequest | None = None) -> list[str]:
         """Get the required permissions.
 
         Returns list of permissions in format *<app_label>.<codename>* that

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from functools import lru_cache, partial
 from itertools import groupby
-from typing import Any, Optional, Type, TypeVar, Union
+from typing import Any, TypeVar
 import warnings
 
 from django.apps import apps
@@ -63,7 +63,7 @@ def _get_first(t):
     return t[0]
 
 
-def _ensure_permission(perm: Union[Permission, str]) -> Permission:
+def _ensure_permission(perm: Permission | str) -> Permission:
     """Converts string permission to the corresponding django model, if required."""
     if isinstance(perm, str):
         try:
@@ -76,7 +76,7 @@ def _ensure_permission(perm: Union[Permission, str]) -> Permission:
     return perm
 
 
-def _normalize_perm(perm: Union[Permission, str]) -> Union[Permission, str]:
+def _normalize_perm(perm: Permission | str) -> Permission | str:
     """Normalizes permission codename, if it is a string."""
     if isinstance(perm, str) and "." in perm:
         _, perm = perm.split(".", 1)
@@ -85,10 +85,10 @@ def _normalize_perm(perm: Union[Permission, str]) -> Union[Permission, str]:
 
 
 def assign_perm(
-    perm: Union[str, Permission],
+    perm: str | Permission,
     user_or_group: Any,
-    obj: Optional[Model] = None,
-) -> Union[str, Permission, None]:
+    obj: Model | None = None,
+) -> str | Permission | None:
     """Assigns permission to user/group and object pair.
 
     Parameters:
@@ -191,10 +191,10 @@ def assign(perm, user_or_group, obj=None):
 
 
 def remove_perm(
-    perm: Union[str, Permission],
+    perm: str | Permission,
     user_or_group: Any = None,
-    obj: Union[Model, QuerySet, list, None] = None,
-) -> Union[tuple[int, dict], None]:
+    obj: Model | QuerySet | list | None = None,
+) -> tuple[int, dict] | None:
     """Removes permission from user/group and object pair.
 
     Parameters:
@@ -324,7 +324,7 @@ def get_group_perms(user_or_group: Any, obj: Model) -> QuerySet[Permission]:
     return check.get_group_perms(obj)
 
 
-def get_perms_for_model(cls: Union[Type[Model], Model, str]) -> QuerySet:
+def get_perms_for_model(cls: type[Model] | Model | str) -> QuerySet:
     """Get all permissions for a given model class.
 
     Returns:
@@ -345,8 +345,8 @@ def get_users_with_perms(
     attach_perms: bool = False,
     with_superusers: bool = False,
     with_group_users: bool = True,
-    only_with_perms_in: Optional[list[str]] = None,
-) -> Union[Any, list[str]]:
+    only_with_perms_in: list[str] | None = None,
+) -> Any | list[str]:
     """Get all users with *any* object permissions for the given `obj`.
 
     Parameters:
@@ -444,8 +444,8 @@ def get_users_with_perms(
 
 
 def get_groups_with_perms(
-    obj: Model, attach_perms: bool = False, only_with_perms_in: Optional[list[str]] = None
-) -> Union[Group, dict]:
+    obj: Model, attach_perms: bool = False, only_with_perms_in: list[str] | None = None
+) -> Group | dict:
     """Get all groups with *any* object permissions for the given `obj`.
 
     Parameters:
@@ -518,8 +518,8 @@ T = TypeVar("T", bound=Model)
 
 
 def _compute_codenames_and_ctype(
-    perms: Union[str, list[str]],
-) -> tuple[Optional[ContentType], set[str]]:
+    perms: str | list[str],
+) -> tuple[ContentType | None, set[str]]:
     """Extracts ContentType and codenames from given list of permissions."""
     if isinstance(perms, str):
         perms = [perms]
@@ -549,8 +549,8 @@ def _compute_codenames_and_ctype(
 
 
 def _compute_queryset(
-    ctype: Optional[ContentType],
-    klass: Union[Type[T], Manager[T], QuerySet[T], None],
+    ctype: ContentType | None,
+    klass: type[T] | Manager[T] | QuerySet[T] | None,
 ) -> tuple[ContentType, QuerySet[T]]:
     """Computes QuerySet and ContentType if still missing"""
     if ctype is None and klass is not None:
@@ -569,8 +569,8 @@ def _compute_queryset(
 
 def get_objects_for_user(
     user: Any,
-    perms: Union[str, list[str]],
-    klass: Union[Type[T], Manager[T], QuerySet[T], None] = None,
+    perms: str | list[str],
+    klass: type[T] | Manager[T] | QuerySet[T] | None = None,
     use_groups: bool = True,
     any_perm: bool = False,
     with_superuser: bool = True,
@@ -802,8 +802,8 @@ def get_objects_for_user(
 
 def get_objects_for_group(
     group: Group,
-    perms: Union[str, list[str]],
-    klass: Union[Type[T], Manager[T], QuerySet[T], None] = None,
+    perms: str | list[str],
+    klass: type[T] | Manager[T] | QuerySet[T] | None = None,
     any_perm: bool = False,
     accept_global_perms: bool = True,
 ) -> QuerySet[T]:
@@ -999,6 +999,6 @@ def filter_perms_queryset_by_objects(perms_queryset, objects):
                 objects = objects.values_list("pk", flat=True)
         else:
             objects = objects.values_list("pk", flat=True)
-        return perms_queryset.filter(**{"{}__in".format(field): objects})
+        return perms_queryset.filter(**{f"{field}__in": objects})
     else:
         return perms_queryset

--- a/guardian/utils.py
+++ b/guardian/utils.py
@@ -11,7 +11,7 @@ import logging
 from math import ceil
 import os
 import time
-from typing import Any, Optional, Union
+from typing import Any
 
 from django.apps import apps as django_apps
 from django.conf import settings
@@ -89,7 +89,7 @@ def get_anonymous_user() -> Any:
         return _get_anonymous_user_uncached()
 
 
-def get_identity(identity: Model) -> tuple[Union[Any, None], Union[Any, None]]:
+def get_identity(identity: Model) -> tuple[Any | None, Any | None]:
     """Get a tuple with the identity of the given input.
 
     Returns a tuple with one of the members set to `None` depending on whether the input is
@@ -159,21 +159,15 @@ def get_identity(identity: Model) -> tuple[Union[Any, None], Union[Any, None]]:
 def get_40x_or_None(
     request: HttpRequest,
     perms: list[str],
-    obj: Optional[Any] = None,
-    login_url: Optional[Any] = None,
-    redirect_field_name: Optional[str] = None,
+    obj: Any | None = None,
+    login_url: Any | None = None,
+    redirect_field_name: str | None = None,
     return_403: bool = False,
     return_404: bool = False,
     permission_denied_message: str = "",
     accept_global_perms: bool = False,
     any_perm: bool = False,
-) -> Union[
-    HttpResponseForbidden,
-    HttpResponseNotFound,
-    HttpResponseRedirect,
-    HttpResponse,
-    None,
-]:
+) -> HttpResponseForbidden | HttpResponseNotFound | HttpResponseRedirect | HttpResponse | None:
     login_url = login_url or settings.LOGIN_URL
     redirect_field_name = redirect_field_name or REDIRECT_FIELD_NAME
 
@@ -236,17 +230,17 @@ def get_obj_perm_model_by_conf(setting_name: str) -> type[Model]:
     try:
         return django_apps.get_model(setting_value, require_ready=False)  # type: ignore
     except ValueError as e:
-        raise ImproperlyConfigured("{} must be of the form 'app_label.model_name'".format(setting_value)) from e
+        raise ImproperlyConfigured(f"{setting_value} must be of the form 'app_label.model_name'") from e
     except LookupError as e:
         raise ImproperlyConfigured(
-            "{} refers to model '{}' that has not been installed".format(setting_name, setting_value)
+            f"{setting_name} refers to model '{setting_value}' that has not been installed"
         ) from e
 
 
 def clean_orphan_obj_perms(
-    batch_size: Optional[int] = None,
-    max_batches: Optional[int] = None,
-    max_duration_secs: Optional[int] = None,
+    batch_size: int | None = None,
+    max_batches: int | None = None,
+    max_duration_secs: int | None = None,
     skip_batches: int = 0,
 ) -> int:
     """
@@ -415,7 +409,7 @@ def clean_orphan_obj_perms(
 # are defined
 
 
-def get_obj_perms_model(obj: Optional[Model], base_cls: type[Model], generic_cls: type[Model]) -> type[Model]:
+def get_obj_perms_model(obj: Model | None, base_cls: type[Model], generic_cls: type[Model]) -> type[Model]:
     """Return the matching object permission model for the obj class.
 
     Defaults to returning the generic object permission when no direct foreignkey is defined, or obj is None.
@@ -447,7 +441,7 @@ def get_obj_perms_model(obj: Optional[Model], base_cls: type[Model], generic_cls
     return generic_cls
 
 
-def get_user_obj_perms_model(obj: Optional[Model] = None) -> type[Model]:
+def get_user_obj_perms_model(obj: Model | None = None) -> type[Model]:
     """Returns model class that connects given `obj` and User class.
 
     If obj is not specified, then the user generic object permission model
@@ -459,7 +453,7 @@ def get_user_obj_perms_model(obj: Optional[Model] = None) -> type[Model]:
     return get_obj_perms_model(obj, UserObjectPermissionBase, UserObjectPermission)
 
 
-def get_group_obj_perms_model(obj: Optional[Model] = None) -> type[Model]:
+def get_group_obj_perms_model(obj: Model | None = None) -> type[Model]:
     """Returns model class that connects given `obj` and Group class.
 
     If obj is not specified, then the group generic object permission model


### PR DESCRIPTION
The pyupgrade hook was configured without a target version, so it ran with the tool's oldest default and left most of the codebase alone. 

Set it to match `requires-python = ">=3.10"` from pyproject.toml.