### PR TITLE
Micro-cleanup: truthiness checks and redundant pass statements

### DIFF
--- a/guardian/managers.py
+++ b/guardian/managers.py
@@ -228,13 +228,9 @@ class UserObjectPermissionManager(BaseObjectPermissionManager):
         `guardian.managers.UserObjectPermissionManager`
     """
 
-    pass
-
 
 class GroupObjectPermissionManager(BaseObjectPermissionManager):
     """
     See Also:
         `guardian.managers.UserObjectPermissionManager`
     """
-
-    pass

--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -3,6 +3,7 @@
 from collections import defaultdict
 from functools import lru_cache, partial
 from itertools import groupby
+from operator import itemgetter
 from typing import Any, Optional, Type, TypeVar, Union
 import warnings
 
@@ -58,9 +59,8 @@ def clear_ct_cache(**kwargs) -> None:
     _get_ct_cached.cache_clear()
 
 
-def _get_first(t):
-    """Allow sorting/grouping by pk by returning first in result tuple"""
-    return t[0]
+# Allow sorting/grouping by pk by returning first in result tuple
+_get_first = itemgetter(0)
 
 
 def _ensure_permission(perm: Union[Permission, str]) -> Permission:
@@ -702,7 +702,7 @@ def get_objects_for_user(
         # OR
         # 2. any_perm is True, then the global permission beats the object based permission anyway,
         # therefore return full queryset
-        if len(global_perms) > 0 and (len(codenames) == 0 or any_perm):
+        if global_perms and (not codenames or any_perm):
             return queryset
         # if we have global perms and still some object based perms differing from global perms and any_perm is set
         # to false, then we have to flag that global perms exist in order to merge object based permissions by user
@@ -710,7 +710,7 @@ def get_objects_for_user(
         # and object based permission delete_xx  on object B for group, to which user is assigned.
         # get_objects_for_user(user, [change_xx, delete_xx], use_groups=True, any_perm=False, accept_global_perms=True)
         # must retrieve object A and B.
-        elif len(global_perms) > 0 and (len(codenames) > 0):
+        elif global_perms and codenames:
             has_global_perms = True
 
     # Now we should extract the list of pk values for which we would filter the queryset
@@ -718,7 +718,7 @@ def get_objects_for_user(
     user_obj_perms_queryset = filter_perms_queryset_by_objects(
         user_model.objects.filter(user=user).filter(permission__content_type=ctype), klass
     )
-    if len(codenames):
+    if codenames:
         user_obj_perms_queryset = user_obj_perms_queryset.filter(permission__codename__in=codenames)
     direct_fields = ["content_object__pk", "permission__codename"]
     generic_fields = ["object_pk", "permission__codename"]
@@ -733,7 +733,7 @@ def get_objects_for_user(
             "permission__content_type": ctype,
             "group__in": user.groups.all(),
         }
-        if len(codenames):
+        if codenames:
             group_filters.update(
                 {
                     "permission__codename__in": codenames,
@@ -887,7 +887,7 @@ def get_objects_for_group(
                 global_perms.add(code)
         for code in global_perms:
             codenames.remove(code)
-        if len(global_perms) > 0 and (len(codenames) == 0 or any_perm):
+        if global_perms and (not codenames or any_perm):
             return queryset
 
     # Now we should extract list of pk values for which we would filter
@@ -896,13 +896,13 @@ def get_objects_for_group(
     groups_obj_perms_queryset = filter_perms_queryset_by_objects(
         group_model.objects.filter(group=group).filter(permission__content_type=ctype), klass
     )
-    if len(codenames):
+    if codenames:
         groups_obj_perms_queryset = groups_obj_perms_queryset.filter(permission__codename__in=codenames)
     if group_model.objects.is_generic():
         fields = ["object_pk", "permission__codename"]
     else:
         fields = ["content_object__pk", "permission__codename"]
-    if not any_perm and len(codenames):
+    if not any_perm and codenames:
         groups_obj_perms = groups_obj_perms_queryset.values_list(*fields)
         data = list(groups_obj_perms)
 


### PR DESCRIPTION
Micro-cleanup: truthiness checks and redundant pass statements

- _get_first as itemgetter(0) instead of a wrapper function
- len(x) > 0 / len(x) == 0 as plain truthiness where x is only
  ever used as a boolean, not compared numerically
- drop redundant pass in manager subclasses that already have
  a docstring