### PR TITLE
Avoid extra query for group_ids in get_users_with_perms

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -419,9 +419,7 @@ def get_users_with_perms(
                         "permission_id__in": permission_ids,
                     }
                 )
-            group_ids = set(
-                group_model.objects.filter(**group_obj_perm_filters).values_list("group_id", flat=True).distinct()
-            )
+            group_ids = group_model.objects.filter(**group_obj_perm_filters).values("group_id").distinct()
             qset = qset | Q(groups__in=group_ids)
         if with_superusers:
             qset = qset | Q(is_superuser=True)

--- a/guardian/testapp/tests/test_shortcuts.py
+++ b/guardian/testapp/tests/test_shortcuts.py
@@ -565,6 +565,15 @@ class GetUsersWithPermsTest(TestCase):
             {user.username for user in (self.user1, self.user2)},
         )
 
+    def test_with_group_users_resolves_group_ids_as_subquery(self):
+        self.user1.groups.add(self.group1)
+        assign_perm("change_contenttype", self.group1, self.obj1)
+        assign_perm("change_contenttype", self.user2, self.obj1)
+
+        with self.assertNumQueries(1):
+            result = get_users_with_perms(self.obj1, with_group_users=True)
+            list(result)
+
     def test_only_with_perms_in_groups(self):
         assign_perm("change_contenttype", self.group1, self.obj1)
         assign_perm("delete_contenttype", self.group2, self.obj1)


### PR DESCRIPTION
Materializing `group_ids` with `set(...values_list(...))` forces an immediate query plus a literal `IN(...)` list.

Keeping it as a queryset lets Django fold it into the final query as a subquery.