### PR TITLE
Collapse integer PK field tuple in _handle_pk_field

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -12,7 +12,6 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db import connection
 from django.db.models import (
-    AutoField,
     BigIntegerField,
     CharField,
     Count,
@@ -20,11 +19,8 @@ from django.db.models import (
     IntegerField,
     Manager,
     Model,
-    PositiveIntegerField,
-    PositiveSmallIntegerField,
     Q,
     QuerySet,
-    SmallIntegerField,
     UUIDField,
 )
 from django.db.models.expressions import Value
@@ -940,17 +936,7 @@ def _handle_pk_field(queryset):
     if isinstance(pk, ForeignKey):
         return _handle_pk_field(pk.target_field)
 
-    if isinstance(
-        pk,
-        (
-            IntegerField,
-            AutoField,
-            BigIntegerField,
-            PositiveIntegerField,
-            PositiveSmallIntegerField,
-            SmallIntegerField,
-        ),
-    ):
+    if isinstance(pk, IntegerField):
         return partial(Cast, output_field=BigIntegerField())
 
     if isinstance(pk, UUIDField):


### PR DESCRIPTION
`AutoField`, `BigIntegerField`, `PositiveIntegerField`,`PositiveSmallIntegerField` and `SmallIntegerField` **all** subclass `IntegerField`, so the tuple check was fully redundant.